### PR TITLE
Add UI instruction for i18n Arches url in placeholder

### DIFF
--- a/arches_project/core/utils/format_url.py
+++ b/arches_project/core/utils/format_url.py
@@ -1,6 +1,11 @@
 def format_url(url_input):
-    # formatted_url = self.dlg.archesServerInput.text().strip()
+    """
+    Simple function to fix any possible user input errors.
+    Strips any leading/trailing whitespace and a trailing slash.
+    """
+
     formatted_url = url_input.strip()
     if formatted_url[-1] == "/":
         formatted_url = formatted_url[:-1]
+
     return formatted_url

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -48,7 +48,7 @@
       </font>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -185,12 +185,16 @@
                  <item>
                   <widget class="QLabel" name="archesServerLabel">
                    <property name="text">
-                    <string>Arches Server e.g. http://arches-server.com</string>
+                    <string>Arches Server</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="archesServerInput"/>
+                  <widget class="QLineEdit" name="archesServerInput">
+                   <property name="placeholderText">
+                    <string>e.g. http://arches-server.com[/language]</string>
+                   </property>
+                  </widget>
                  </item>
                 </layout>
                </widget>
@@ -215,7 +219,11 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="usernameInput"/>
+                  <widget class="QLineEdit" name="usernameInput">
+                   <property name="placeholderText">
+                    <string>e.g. admin</string>
+                   </property>
+                  </widget>
                  </item>
                 </layout>
                </widget>


### PR DESCRIPTION
closes #32 

i18n/language url extensions are supported in the plugin, they just need to be included in the url otherwise it will fail.

<img width="563" height="741" alt="image" src="https://github.com/user-attachments/assets/b5c56fb5-ea42-4817-b367-c64661d73d14" />
