### PR TITLE
Fix mouse scrolling through non-visible tabs

### DIFF
--- a/arches_project/arches_project.py
+++ b/arches_project/arches_project.py
@@ -224,6 +224,19 @@ class ArchesProject:
                 action)
             self.iface.removeToolBarIcon(action)
 
+    def reset_tabs(self):
+        """Resets the tabs to just the login screen and settings"""
+        self.removedTabs = []
+
+        for i in reversed(range(self.dlg.tabWidget.count())):
+                tab = self.dlg.tabWidget.widget(i)
+                tabName = self.dlg.tabWidget.widget(i).objectName()
+                icon = self.dlg.tabWidget.tabIcon(i)
+
+                if tabName not in ["connection", "settings"]:
+                    self.removedTabs.append({"tab": tab, "index": i, "icon": icon, "label": tabName})
+                    self.dlg.tabWidget.removeTab(i)
+
     def run(self):
         """Run method that performs all the real work"""
 
@@ -258,16 +271,7 @@ class ArchesProject:
             # Set tab index to 0 always
             self.dlg.tabWidget.setCurrentIndex(0)
 
-            self.removedTabs = []
-
-            for i in reversed(range(self.dlg.tabWidget.count())):
-                tab = self.dlg.tabWidget.widget(i)
-                tabName = self.dlg.tabWidget.widget(i).objectName()
-                icon = self.dlg.tabWidget.tabIcon(i)
-
-                if tabName not in ["connection", "settings"]:
-                    self.removedTabs.append({"tab": tab, "index": i, "icon": icon, "label": tabName})
-                    self.dlg.tabWidget.removeTab(i)
+            self.reset_tabs()
 
             self.dlg.enableLoggingCheckbox.stateChanged.connect(enable_logging)
 

--- a/arches_project/arches_project.py
+++ b/arches_project/arches_project.py
@@ -224,7 +224,7 @@ class ArchesProject:
                 action)
             self.iface.removeToolBarIcon(action)
 
-    def reset_tabs(self):
+    def remove_tabs(self):
         """Resets the tabs to just the login screen and settings"""
         self.removedTabs = []
 
@@ -268,10 +268,11 @@ class ArchesProject:
             ## Have everything called in here so multiple connections aren't made when plugin button pressed
             # This way only one connection is made at a time
 
+            # Remove most tabs until connected
+            self.remove_tabs()
+
             # Set tab index to 0 always
             self.dlg.tabWidget.setCurrentIndex(0)
-
-            self.reset_tabs()
 
             self.dlg.enableLoggingCheckbox.stateChanged.connect(enable_logging)
 
@@ -567,9 +568,16 @@ class ArchesProject:
             # It is an existing QGIS issue https://github.com/qgis/QGIS/issues/37655
             QgsMessageLog.logMessage("Connection task started")
 
+        # Re-add previously removed tabs
         for tab in reversed(self.removedTabs):
             self.dlg.tabWidget.insertTab(tab["index"], tab["tab"], tab["icon"], "")
 
-        self.dlg.tabWidget.setTabEnabled(0, False)
-    
+        # Remove login tab
+        self.removedTabs = [{
+            "tab": self.dlg.tabWidget.widget(0),
+            "index": 0,
+            "icon": self.dlg.tabWidget.tabIcon(0),
+            "label": self.dlg.tabWidget.widget(0).objectName()
+        }]
 
+        self.dlg.tabWidget.removeTab(0)

--- a/arches_project/arches_project.py
+++ b/arches_project/arches_project.py
@@ -257,8 +257,17 @@ class ArchesProject:
 
             # Set tab index to 0 always
             self.dlg.tabWidget.setCurrentIndex(0)
-            self.dlg.tabWidget.setTabVisible(1, False)
-            self.dlg.tabWidget.setTabVisible(5, False)
+
+            self.removedTabs = []
+
+            for i in reversed(range(self.dlg.tabWidget.count())):
+                tab = self.dlg.tabWidget.widget(i)
+                tabName = self.dlg.tabWidget.widget(i).objectName()
+                icon = self.dlg.tabWidget.tabIcon(i)
+
+                if tabName not in ["connection", "settings"]:
+                    self.removedTabs.append({"tab": tab, "index": i, "icon": icon, "label": tabName})
+                    self.dlg.tabWidget.removeTab(i)
 
             self.dlg.enableLoggingCheckbox.stateChanged.connect(enable_logging)
 
@@ -553,3 +562,10 @@ class ArchesProject:
             # A log message (or print) is required for the task to be run.
             # It is an existing QGIS issue https://github.com/qgis/QGIS/issues/37655
             QgsMessageLog.logMessage("Connection task started")
+
+        for tab in reversed(self.removedTabs):
+            self.dlg.tabWidget.insertTab(tab["index"], tab["tab"], tab["icon"], "")
+
+        self.dlg.tabWidget.setTabEnabled(0, False)
+    
+

--- a/arches_project/core/arches/connection.py
+++ b/arches_project/core/arches/connection.py
@@ -139,9 +139,10 @@ class ArchesConnection():
             self_obj.dlg.displayFullNameLabel.setText("")
             self_obj.dlg.displayConnectionInfoLabel.setText("")
             self_obj.dlg.displayUsernameLabel.setText("")
-            # Replace login tab with logged in tab
-            self_obj.dlg.tabWidget.setTabVisible(0, True)
-            self_obj.dlg.tabWidget.setTabVisible(1, False)
+            # Re-add login tab and remove most other tabs
+            for tab in reversed(self_obj.removedTabs):
+                self_obj.dlg.tabWidget.insertTab(tab["index"], tab["tab"], tab["icon"], "")
+            self_obj.remove_tabs()
             self_obj.dlg.tabWidget.setCurrentIndex(0)
 
         # Reset stored data
@@ -226,11 +227,6 @@ class ConnectionProcess(QgsTask):
 
     def finished(self, result):
         def update_login_tab():
-            # Replace login tab with logged in tab
-            self.archesproject.dlg.tabWidget.setTabVisible(0, False)
-            self.archesproject.dlg.tabWidget.setTabVisible(1, True)
-            self.archesproject.dlg.tabWidget.setCurrentIndex(1)
-
             logged_in_tab = LoggedIn(dlg = self.archesproject.dlg,
                                      username = self.username,
                                      url = self.url,


### PR DESCRIPTION
Closes https://github.com/archesproject/arches-qgis/issues/2

Tabs need to be removed from the tabWidget completely in order to prevent then from being accessible via mouse scrolling. They can then be stored within the `archesproject` until they need to be reinserted. This replaces the previous method of setting tab visibility as `true` or `false`. 

Some of the new code added to `connection_reset` could possibly be moved to `finished`, but I haven't tested this. 
