### PR TITLE
Explicitly look up the geometry type label

### DIFF
--- a/arches_project/core/utils/geometry_conversion.py
+++ b/arches_project/core/utils/geometry_conversion.py
@@ -1,6 +1,7 @@
 from qgis.core import (QgsProject,
                        QgsCoordinateReferenceSystem,
                        QgsCoordinateTransform,
+                       QgsWkbTypes
                        )
 
 class Geometries():
@@ -34,11 +35,12 @@ class Geometries():
             all_features.append(geom.asWkt())
 
             # Store types 
-            geomtype = str(geom.type()).split(".")
-            if geomtype[-1] not in geometry_type_dict:
-                geometry_type_dict[geomtype[-1]] = 1
+            geom_type = geom.type()
+            geom_type_label = QgsWkbTypes.geometryDisplayString(geom_type)
+            if geom_type_label not in geometry_type_dict:
+                geometry_type_dict[geom_type_label] = 1
             else:
-                geometry_type_dict[geomtype[-1]] += 1
+                geometry_type_dict[geom_type_label] += 1
 
         # Would use shapely to create GEOMETRYCOLLECTION but that'd require users to install the dependency themselves
         # this is the alternative        


### PR DESCRIPTION
The type method on the geometry class returns a geometry_type object. This doesn't seem to have it's own method for printing as a meaningful string, but you can pass it to a method on QgsWkbTypes which converts it. 

The confirmation dialog then shows as expected:

<img width="392" height="271" alt="image" src="https://github.com/user-attachments/assets/b8d04a10-0112-4b43-b8cd-e6159417d599" />
