### PR TITLE
Restructure stylesheets

### DIFF
--- a/arches_project/arches_project.py
+++ b/arches_project/arches_project.py
@@ -34,7 +34,6 @@ from arches_project.ui.arches_project_dialog import ArchesProjectDialog
 # Import the confirmation dialog
 from .ui.resource_confirmation_dialog import ResourceConfirmation
 
-from arches_project.core.views.stylesheets import PluginStylesheets
 from arches_project.core.views.components.map import update_map_layers, map_selection
 
 import os.path
@@ -211,24 +210,6 @@ class ArchesProject:
         # Only create GUI ONCE in callback, so that it will only load when the plugin is started
         if self.first_start == True:
             self.first_start = False
-
-            # Setup Arches Stylesheet
-            PluginStylesheets(
-                dlg=self.dlg,
-                dlg_resource_confirmation=self.dlg_resource_confirmation,
-                on_start=True,
-                plugin_dir=self.plugin_dir,
-            )
-            # if stylesheet is disabled
-            self.dlg.useStylesheetCheckbox.stateChanged.connect(
-                partial(
-                    PluginStylesheets,
-                    dlg=self.dlg,
-                    dlg_resource_confirmation=self.dlg_resource_confirmation,
-                    on_start=False,
-                    plugin_dir=self.plugin_dir,
-                )
-            )
 
         # show the dialog
         self.dlg.show()

--- a/arches_project/core/views/stylesheets/arches.py
+++ b/arches_project/core/views/stylesheets/arches.py
@@ -6,14 +6,7 @@ import os
 
 
 class ArchesStylesheet:
-    def __init__(
-        self,
-        dlg,
-        dlg_resource_creation,
-        dlg_edit_resource_add,
-        dlg_edit_resource_replace,
-        plugin_dir,
-    ):
+    def __init__(self, dlg, dlg_resource_confirmation, plugin_dir):
         self.dlg = dlg
         self.dlg_resource_confirmation = dlg_resource_confirmation
         self.plugin_dir = plugin_dir

--- a/arches_project/core/views/stylesheets/arches.py
+++ b/arches_project/core/views/stylesheets/arches.py
@@ -5,58 +5,18 @@ from PyQt5.QtCore import Qt
 import os
 
 
-class PluginStylesheets:
-    def __init__(self, dlg, dlg_resource_confirmation, plugin_dir, on_start):
+class ArchesStylesheet:
+    def __init__(
+        self,
+        dlg,
+        dlg_resource_creation,
+        dlg_edit_resource_add,
+        dlg_edit_resource_replace,
+        plugin_dir,
+    ):
         self.dlg = dlg
         self.dlg_resource_confirmation = dlg_resource_confirmation
         self.plugin_dir = plugin_dir
-        self.on_start = on_start
-
-        # hide loading wheel adjustments
-        self.dlg.loadingWheel.hide()  # connection wheel label
-        self.dlg.updateTextFrame.hide()
-        self.dlg.loginErrorMessageFrame.hide()
-        self.dlg.loadingWheelVerticalSpacerFrame.hide()
-        self.dlg.createResOutputBoxFrame.hide()
-
-        if not self.dlg.useStylesheetCheckbox.isChecked():
-            self.default_stylesheet()
-        elif self.dlg.useStylesheetCheckbox.isChecked():
-            self.arches_stylesheet()
-
-        if self.on_start == True:
-            self.arches_stylesheet()
-
-    def default_stylesheet(self):
-        # reset stylesheets
-        self.dlg.setStyleSheet("")
-        self.dlg_resource_confirmation.setStyleSheet("")
-        # remove icons from buttons
-        self.dlg.btnConnect.setIcon(QIcon(""))
-        self.dlg.btnLogout.setIcon(QIcon(""))
-        self.dlg.createResButton.setIcon(QIcon(""))
-        self.dlg.editResAddGeom.setIcon(QIcon(""))
-        self.dlg.editResReplaceGeom.setIcon(QIcon(""))
-        self.dlg_resource_confirmation.confirmDialogCancel.setIcon(QIcon(""))
-        self.dlg_resource_confirmation.confirmDialogConfirm.setIcon(QIcon(""))
-        # nav bar
-        # TODO: don't like the fact I have to add the exact strings (from qtcreator) back to the tab titles, seems like could be a better method...
-        self.dlg.tabWidget.setStyleSheet(" QTabWidget {qproperty-tabPosition: North;} ")
-        self.dlg.tabWidget.setStyleSheet("")
-
-        self.dlg.tabWidget.setAutoFillBackground(False)
-        self.dlg.tabWidget.setTabIcon(0, QIcon(""))
-        self.dlg.tabWidget.setTabText(0, "Arches Connection")
-        self.dlg.tabWidget.setTabIcon(1, QIcon(""))
-        self.dlg.tabWidget.setTabText(1, "Arches Connection")
-        self.dlg.tabWidget.setTabIcon(2, QIcon(""))
-        self.dlg.tabWidget.setTabText(2, "Create Resource")
-        self.dlg.tabWidget.setTabIcon(3, QIcon(""))
-        self.dlg.tabWidget.setTabText(3, "Edit Resource")
-        self.dlg.tabWidget.setTabIcon(4, QIcon(""))
-        self.dlg.tabWidget.setTabText(4, "Settings")
-        self.dlg.tabWidget.setTabIcon(5, QIcon(""))
-        self.dlg.tabWidget.setTabText(5, "Log")
 
     def arches_stylesheet(self):
         try:

--- a/arches_project/core/views/stylesheets/default.py
+++ b/arches_project/core/views/stylesheets/default.py
@@ -2,36 +2,22 @@ from qgis.PyQt.QtGui import QIcon
 
 
 class DefaultStylesheet:
-    def __init__(
-        self,
-        dlg,
-        dlg_resource_creation,
-        dlg_edit_resource_add,
-        dlg_edit_resource_replace,
-    ):
+    def __init__(self, dlg, dlg_resource_confirmation):
         self.dlg = dlg
-        self.dlg_resource_creation = dlg_resource_creation
-        self.dlg_edit_resource_add = dlg_edit_resource_add
-        self.dlg_edit_resource_replace = dlg_edit_resource_replace
+        self.dlg_resource_confirmation = dlg_resource_confirmation
 
     def default_stylesheet(self):
         # reset stylesheets
         self.dlg.setStyleSheet("")
-        self.dlg_resource_creation.setStyleSheet("")
-        self.dlg_edit_resource_add.setStyleSheet("")
-        self.dlg_edit_resource_replace.setStyleSheet("")
+        self.dlg_resource_confirmation.setStyleSheet("")
         # remove icons from buttons
         self.dlg.btnConnect.setIcon(QIcon(""))
         self.dlg.btnLogout.setIcon(QIcon(""))
-        self.dlg.addNewRes.setIcon(QIcon(""))
-        self.dlg.addEditRes.setIcon(QIcon(""))
-        self.dlg.replaceEditRes.setIcon(QIcon(""))
-        self.dlg_resource_creation.createDialogCancel.setIcon(QIcon(""))
-        self.dlg_resource_creation.createDialogCreate.setIcon(QIcon(""))
-        self.dlg_edit_resource_add.editDialogCancel.setIcon(QIcon(""))
-        self.dlg_edit_resource_add.editDialogCreate.setIcon(QIcon(""))
-        self.dlg_edit_resource_replace.editDialogCancel.setIcon(QIcon(""))
-        self.dlg_edit_resource_replace.editDialogCreate.setIcon(QIcon(""))
+        self.dlg.createResButton.setIcon(QIcon(""))
+        self.dlg.editResAddGeom.setIcon(QIcon(""))
+        self.dlg.editResReplaceGeom.setIcon(QIcon(""))
+        self.dlg_resource_confirmation.confirmDialogCancel.setIcon(QIcon(""))
+        self.dlg_resource_confirmation.confirmDialogConfirm.setIcon(QIcon(""))
         # nav bar
         # TODO: don't like the fact I have to add the exact strings (from qtcreator) back to the tab titles, seems like could be a better method...
         self.dlg.tabWidget.setStyleSheet(" QTabWidget {qproperty-tabPosition: North;} ")

--- a/arches_project/core/views/stylesheets/default.py
+++ b/arches_project/core/views/stylesheets/default.py
@@ -1,0 +1,52 @@
+from qgis.PyQt.QtGui import QIcon
+
+
+class DefaultStylesheet:
+    def __init__(
+        self,
+        dlg,
+        dlg_resource_creation,
+        dlg_edit_resource_add,
+        dlg_edit_resource_replace,
+    ):
+        self.dlg = dlg
+        self.dlg_resource_creation = dlg_resource_creation
+        self.dlg_edit_resource_add = dlg_edit_resource_add
+        self.dlg_edit_resource_replace = dlg_edit_resource_replace
+
+    def default_stylesheet(self):
+        # reset stylesheets
+        self.dlg.setStyleSheet("")
+        self.dlg_resource_creation.setStyleSheet("")
+        self.dlg_edit_resource_add.setStyleSheet("")
+        self.dlg_edit_resource_replace.setStyleSheet("")
+        # remove icons from buttons
+        self.dlg.btnConnect.setIcon(QIcon(""))
+        self.dlg.btnLogout.setIcon(QIcon(""))
+        self.dlg.addNewRes.setIcon(QIcon(""))
+        self.dlg.addEditRes.setIcon(QIcon(""))
+        self.dlg.replaceEditRes.setIcon(QIcon(""))
+        self.dlg_resource_creation.createDialogCancel.setIcon(QIcon(""))
+        self.dlg_resource_creation.createDialogCreate.setIcon(QIcon(""))
+        self.dlg_edit_resource_add.editDialogCancel.setIcon(QIcon(""))
+        self.dlg_edit_resource_add.editDialogCreate.setIcon(QIcon(""))
+        self.dlg_edit_resource_replace.editDialogCancel.setIcon(QIcon(""))
+        self.dlg_edit_resource_replace.editDialogCreate.setIcon(QIcon(""))
+        # nav bar
+        # TODO: don't like the fact I have to add the exact strings (from qtcreator) back to the tab titles, seems like could be a better method...
+        self.dlg.tabWidget.setStyleSheet(" QTabWidget {qproperty-tabPosition: North;} ")
+        self.dlg.tabWidget.setStyleSheet("")
+
+        self.dlg.tabWidget.setAutoFillBackground(False)
+        self.dlg.tabWidget.setTabIcon(0, QIcon(""))
+        self.dlg.tabWidget.setTabText(0, "Arches Connection")
+        self.dlg.tabWidget.setTabIcon(1, QIcon(""))
+        self.dlg.tabWidget.setTabText(1, "Arches Connection")
+        self.dlg.tabWidget.setTabIcon(2, QIcon(""))
+        self.dlg.tabWidget.setTabText(2, "Create Resource")
+        self.dlg.tabWidget.setTabIcon(3, QIcon(""))
+        self.dlg.tabWidget.setTabText(3, "Edit Resource")
+        self.dlg.tabWidget.setTabIcon(4, QIcon(""))
+        self.dlg.tabWidget.setTabText(4, "Settings")
+        self.dlg.tabWidget.setTabIcon(5, QIcon(""))
+        self.dlg.tabWidget.setTabText(5, "Log")

--- a/arches_project/core/views/stylesheets/stylesheets.py
+++ b/arches_project/core/views/stylesheets/stylesheets.py
@@ -1,0 +1,42 @@
+from arches_project.core.views.stylesheets.arches import ArchesStylesheet
+from arches_project.core.views.stylesheets.default import DefaultStylesheet
+
+
+class Stylesheets:
+    def __init__(
+        self,
+        dlg,
+        dlg_resource_creation,
+        dlg_edit_resource_add,
+        dlg_edit_resource_replace,
+        plugin_dir,
+    ):
+        self.dlg = dlg
+        self.dlg_resource_creation = dlg_resource_creation
+        self.dlg_edit_resource_add = dlg_edit_resource_add
+        self.dlg_edit_resource_replace = dlg_edit_resource_replace
+        self.plugin_dir = plugin_dir
+
+        self.default_stylesheet = DefaultStylesheet(
+            dlg=self.dlg,
+            dlg_resource_creation=self.dlg_resource_creation,
+            dlg_edit_resource_add=self.dlg_edit_resource_add,
+            dlg_edit_resource_replace=self.dlg_edit_resource_replace,
+        )
+
+        self.arches_stylesheet = ArchesStylesheet(
+            dlg=self.dlg,
+            dlg_resource_creation=self.dlg_resource_creation,
+            dlg_edit_resource_add=self.dlg_edit_resource_add,
+            dlg_edit_resource_replace=self.dlg_edit_resource_replace,
+            plugin_dir=self.plugin_dir,
+        )
+
+        # Set as default
+        self.arches_stylesheet.arches_stylesheet()
+
+    def stylesheet_changed(self):
+        if not self.dlg.useStylesheetCheckbox.isChecked():
+            self.default_stylesheet.default_stylesheet()
+        elif self.dlg.useStylesheetCheckbox.isChecked():
+            self.arches_stylesheet.arches_stylesheet()

--- a/arches_project/core/views/stylesheets/stylesheets.py
+++ b/arches_project/core/views/stylesheets/stylesheets.py
@@ -3,32 +3,19 @@ from arches_project.core.views.stylesheets.default import DefaultStylesheet
 
 
 class Stylesheets:
-    def __init__(
-        self,
-        dlg,
-        dlg_resource_creation,
-        dlg_edit_resource_add,
-        dlg_edit_resource_replace,
-        plugin_dir,
-    ):
+    def __init__(self, dlg, dlg_resource_confirmation, plugin_dir):
         self.dlg = dlg
-        self.dlg_resource_creation = dlg_resource_creation
-        self.dlg_edit_resource_add = dlg_edit_resource_add
-        self.dlg_edit_resource_replace = dlg_edit_resource_replace
+        self.dlg_resource_confirmation = dlg_resource_confirmation
         self.plugin_dir = plugin_dir
 
         self.default_stylesheet = DefaultStylesheet(
             dlg=self.dlg,
-            dlg_resource_creation=self.dlg_resource_creation,
-            dlg_edit_resource_add=self.dlg_edit_resource_add,
-            dlg_edit_resource_replace=self.dlg_edit_resource_replace,
+            dlg_resource_confirmation=self.dlg_resource_confirmation,
         )
 
         self.arches_stylesheet = ArchesStylesheet(
             dlg=self.dlg,
-            dlg_resource_creation=self.dlg_resource_creation,
-            dlg_edit_resource_add=self.dlg_edit_resource_add,
-            dlg_edit_resource_replace=self.dlg_edit_resource_replace,
+            dlg_resource_confirmation=self.dlg_resource_confirmation,
             plugin_dir=self.plugin_dir,
         )
 

--- a/arches_project/tests/base_test.py
+++ b/arches_project/tests/base_test.py
@@ -2,7 +2,6 @@ import unittest
 import os
 
 from arches_project.arches_project import ArchesProject
-from arches_project.core.views.stylesheets import PluginStylesheets
 
 from qgis.PyQt.QtCore import QSettings
 
@@ -34,13 +33,6 @@ class ArchesQGISTestCase(unittest.TestCase):
         # Call the dialogs from within the plugin rather than establishing new ones.
         self.dlg = self.arches_project.dlg
         self.dlg_resource_confirmation = self.arches_project.dlg_resource_confirmation
-
-        PluginStylesheets(
-            self.dlg,
-            self.dlg_resource_confirmation,
-            self.arches_project.plugin_dir,
-            True,
-        )
 
         self.arches_url = (
             f"http://{os.environ.get('ARCHES_HOST')}:{os.environ.get('DJANGO_PORT')}"

--- a/arches_project/ui/arches_project_dialog.py
+++ b/arches_project/ui/arches_project_dialog.py
@@ -38,6 +38,7 @@ from arches_project.core.views.components.multiple_graph_nodes import (
 from arches_project.core.views.components.dialog_updates import connection_reset
 from arches_project.core.views.resources import ResourcesView
 from arches_project.core.views.connection import ArchesConnectionView
+from arches_project.core.views.stylesheets.stylesheets import Stylesheets
 
 from qgis.PyQt import uic
 from qgis.PyQt import QtWidgets
@@ -155,5 +156,26 @@ class ArchesProjectDialog(QtWidgets.QDialog, FORM_CLASS):
                 self.resources_object.edit_resource,
                 replace=True,
                 dlg_resource_confirmation=self.dlg_resource_confirmation,
+            )
+        )
+
+        # hide loading wheel adjustments
+        self.loadingWheel.hide()  # connection wheel label
+        self.updateTextFrame.hide()
+        self.loginErrorMessageFrame.hide()
+        self.loadingWheelVerticalSpacerFrame.hide()
+
+        # Stylesheets
+        self.stylesheets = Stylesheets(
+            dlg=self,
+            dlg_resource_creation=self.dlg_resource_creation,
+            dlg_edit_resource_add=self.dlg_edit_resource_add,
+            dlg_edit_resource_replace=self.dlg_edit_resource_replace,
+            plugin_dir=self.plugin_dir,
+        )
+
+        self.useStylesheetCheckbox.stateChanged.connect(
+            partial(
+                self.stylesheets.stylesheet_changed,
             )
         )

--- a/arches_project/ui/arches_project_dialog.py
+++ b/arches_project/ui/arches_project_dialog.py
@@ -168,9 +168,7 @@ class ArchesProjectDialog(QtWidgets.QDialog, FORM_CLASS):
         # Stylesheets
         self.stylesheets = Stylesheets(
             dlg=self,
-            dlg_resource_creation=self.dlg_resource_creation,
-            dlg_edit_resource_add=self.dlg_edit_resource_add,
-            dlg_edit_resource_replace=self.dlg_edit_resource_replace,
+            dlg_resource_confirmation=self.dlg_resource_confirmation,
             plugin_dir=self.plugin_dir,
         )
 


### PR DESCRIPTION
Closes #80 

This replaces the single stylesheet file and separates out the default, arches, and choice/calling into three files.

The previous structure was one file in `arches_project/core/views/stylesheets.py`.
This new proposed structure is a directory `arches_project/core/views/stylesheets/` and in there live `stylesheets.py` - currently linking to the checkbox and delegating to `arches.py` - the sheet for settings our Arches styles, and `default.py` - the default QGIS stylings.