### PR TITLE
Fix PyQt debug messages when running tests

### DIFF
--- a/arches_project/stylesheets/arches_styling.qss
+++ b/arches_project/stylesheets/arches_styling.qss
@@ -64,7 +64,6 @@ QTabBar {
 QTabBar::tab {
     background-color: #2d3c4b;
     width: 50px;
-    length: 40px;
 } 
 QTabBar::tab:selected { 
     background-color: #2986b8;    

--- a/arches_project/tests/base_test.py
+++ b/arches_project/tests/base_test.py
@@ -50,7 +50,6 @@ class ArchesQGISTestCase(unittest.TestCase):
 
         self.arches_project.first_start = True
         self.arches_project.initGui()
-        self.arches_project.run()
 
     def tearDown(self):
         """


### PR DESCRIPTION
Closes #95 

We no longer need to run the `run()` function in base_test.py since all connections have moved to the dialogs.

The invalid `length` qss property added [here](https://github.com/archesproject/arches-qgis/commit/da9d0d7ca806d5d7ce205baf4a774d9bcf025a72#diff-108d98eb65aa794b09064c6d5b8c42935abd31d34460c01d9cdcbbb91d7e82b6) has been removed.