### PR TITLE
Add test for licence check

### DIFF
--- a/arches_project/tests/test_core/test_init.py
+++ b/arches_project/tests/test_core/test_init.py
@@ -65,6 +65,13 @@ class TestInit(unittest.TestCase):
 
             self.assertIn(expectation, dict(metadata), message)
 
+    def test_license_file(self):
+        """Test that the QGIS plugin package includes a LICENSE file."""
+        file_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "LICENSE")
+        )
+        self.assertTrue(os.path.exists(file_path))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
alpha/1.0.0a2 missed out the second LICENSE file required in the QGIS plugin packaged code. 
This PR introduces a test so this can be caught from now on.

Note: This test WILL FAIL until #100 is merged into dev/1.0.x (the PR that adds the LICENSE file)