### PR TITLE
Fix incorrect metadata icon path

### DIFF
--- a/arches_project/metadata.txt
+++ b/arches_project/metadata.txt
@@ -27,7 +27,7 @@ tags=python
 
 homepage=https://github.com/archesproject/arches-qgis
 category=Plugins
-icon=arches_project/icons/arches.png
+icon=icons/arches.png
 # experimental flag
 experimental=True
 


### PR DESCRIPTION
The path of the icon in metadata.txt was not updated after the recent restructure. It is currently looking in a non-existent dir and thus not resolving. This PR fixes that:
<img width="440" height="178" alt="image" src="https://github.com/user-attachments/assets/0cfc3b38-e54a-45a9-85bc-9d09c8893398" />
