### PR TITLE
Add initial tests for connecting to arches

### DIFF
--- a/arches_project/tests/test_core/test_connection.py
+++ b/arches_project/tests/test_core/test_connection.py
@@ -1,12 +1,10 @@
-import unittest
+from unittest.mock import patch, MagicMock
 import requests
-
-from PyQt5.QtTest import QTest
-from PyQt5.QtCore import Qt
 
 from arches_project.tests.base_test import ArchesQGISTestCase
 
 from arches_project.tests.utils.utilities import get_qgis_app
+from arches_project.core.arches.connection import ConnectionProcess
 
 CANVAS, PARENT, IFACE, QGIS_APP = get_qgis_app()
 
@@ -16,7 +14,10 @@ class ConnectionTests(ArchesQGISTestCase):
     Test connection to Arches server.
     """
 
-    client_id = "ZmRsVUmUtwas8lmgX40PmgAQacESxxv9EPQdIm8S"
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.client_id = "ZmRsVUmUtwas8lmgX40PmgAQacESxxv9EPQdIm8S"
 
     def test_get_clientid(self):
         files = {
@@ -36,3 +37,24 @@ class ConnectionTests(ArchesQGISTestCase):
         }
         response = requests.post(self.arches_url + "/o/token/", data=files)
         self.assertEqual(response.status_code, 200)
+
+    @patch('qgis.core.QgsApplication.taskManager')
+    def test_connection_task_is_added_on_save(self, mock_task_manager):
+        mock_add_task = MagicMock()
+        mock_task_manager.return_value.addTask = mock_add_task
+
+        self.dlg.archesServerInput.setText(self.arches_url)
+        self.dlg.usernameInput.setText("admin")
+        self.dlg.passwordInput.setText("admin")
+
+        self.dlg.arches_connection.arches_connection_save()
+
+        mock_add_task.assert_called_once()
+        added_task = mock_add_task.call_args[0][0]
+
+        self.assertIsInstance(added_task, ConnectionProcess)
+        self.assertEqual(added_task.url, self.arches_url)
+        self.assertEqual(added_task.username, "admin")
+        self.assertEqual(added_task.password, "admin")
+        self.assertEqual(added_task.dlg, self.dlg)
+

--- a/arches_project/tests/test_core/test_connection.py
+++ b/arches_project/tests/test_core/test_connection.py
@@ -38,7 +38,7 @@ class ConnectionTests(ArchesQGISTestCase):
         response = requests.post(self.arches_url + "/o/token/", data=files)
         self.assertEqual(response.status_code, 200)
 
-    @patch('qgis.core.QgsApplication.taskManager')
+    @patch("qgis.core.QgsApplication.taskManager")
     def test_connection_task_is_added_on_save(self, mock_task_manager):
         mock_add_task = MagicMock()
         mock_task_manager.return_value.addTask = mock_add_task
@@ -57,4 +57,3 @@ class ConnectionTests(ArchesQGISTestCase):
         self.assertEqual(added_task.username, "admin")
         self.assertEqual(added_task.password, "admin")
         self.assertEqual(added_task.dlg, self.dlg)
-

--- a/arches_project/tests/test_ui/test_connection.py
+++ b/arches_project/tests/test_ui/test_connection.py
@@ -10,6 +10,7 @@ from arches_project.tests.utils.utilities import get_qgis_app
 
 CANVAS, PARENT, IFACE, QGIS_APP = get_qgis_app()
 
+
 class ConnectionTests(ArchesQGISTestCase):
     """
     Test connection to Arches UI.
@@ -67,26 +68,41 @@ class ConnectionTests(ArchesQGISTestCase):
 
     def test_changes_to_ui_after_connection(self):
         self.arches_connection = ConnectionProcess(
-                url=self.arches_url,
-                username="admin",
-                password="admin",
-                dlg=self.dlg,
-                iface=IFACE,
-                plugin_dir=self.arches_project.plugin_dir,
-            )
-        
+            url=self.arches_url,
+            username="admin",
+            password="admin",
+            dlg=self.dlg,
+            iface=IFACE,
+            plugin_dir=self.arches_project.plugin_dir,
+        )
+
         result = self.arches_connection.run()
         self.arches_connection.finished(result)
 
-        self.assertTrue(result, "ConnectionProcess.run() should return True when given valid credentials")
+        self.assertTrue(
+            result,
+            "ConnectionProcess.run() should return True when given valid credentials",
+        )
 
-        self.assertEqual(self.dlg.tabWidget.currentIndex(), 1, "Logged-in tab should be current tab")
-        self.assertTrue(self.dlg.tabWidget.isTabVisible(1), "Logged-in tab should be visible")
-        self.assertFalse(self.dlg.tabWidget.isTabVisible(0), "Log-in tab should not be visible")
-            
+        self.assertEqual(
+            self.dlg.tabWidget.currentIndex(), 1, "Logged-in tab should be current tab"
+        )
+        self.assertTrue(
+            self.dlg.tabWidget.isTabVisible(1), "Logged-in tab should be visible"
+        )
+        self.assertFalse(
+            self.dlg.tabWidget.isTabVisible(0), "Log-in tab should not be visible"
+        )
+
         # Logged-in tab display changes (when user has no fullname stored)
-        self.assertEqual(self.dlg.displayFullNameLabel.text(), "admin", "Full name label is username")
-        self.assertFalse(self.dlg.displayUsernameLabel.isVisible(), "Username label should be hidden")
-        self.assertFalse(self.dlg.displayUsernameFrame.isVisible(), "Username frame should be hidden")
+        self.assertEqual(
+            self.dlg.displayFullNameLabel.text(), "admin", "Full name label is username"
+        )
+        self.assertFalse(
+            self.dlg.displayUsernameLabel.isVisible(), "Username label should be hidden"
+        )
+        self.assertFalse(
+            self.dlg.displayUsernameFrame.isVisible(), "Username frame should be hidden"
+        )
 
         # TODO: add tests for Create and Edit resource tab UIs once test layers are available in test Arches and QGIS instances

--- a/arches_project/tests/test_ui/test_connection.py
+++ b/arches_project/tests/test_ui/test_connection.py
@@ -1,14 +1,14 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
 from PyQt5.QtTest import QTest
 from PyQt5.QtCore import Qt
 
 from arches_project.tests.base_test import ArchesQGISTestCase
-
+from arches_project.core.arches.connection import ConnectionProcess
 from arches_project.tests.utils.utilities import get_qgis_app
 
 CANVAS, PARENT, IFACE, QGIS_APP = get_qgis_app()
-
 
 class ConnectionTests(ArchesQGISTestCase):
     """
@@ -65,11 +65,28 @@ class ConnectionTests(ArchesQGISTestCase):
                     self.dlg.loginErrorMessageLabel.text(), case["expected_msg"]
                 )
 
-    def test_successful_arches_login(self):
-        self.dlg.archesServerInput.setText(self.arches_url)
-        self.dlg.usernameInput.setText("admin")
-        self.dlg.passwordInput.setText("admin")
+    def test_changes_to_ui_after_connection(self):
+        self.arches_connection = ConnectionProcess(
+                url=self.arches_url,
+                username="admin",
+                password="admin",
+                dlg=self.dlg,
+                iface=IFACE,
+                plugin_dir=self.arches_project.plugin_dir,
+            )
+        
+        result = self.arches_connection.run()
+        self.arches_connection.finished(result)
 
-        QTest.mouseClick(self.dlg.btnConnect, Qt.LeftButton)
+        self.assertTrue(result, "ConnectionProcess.run() should return True when given valid credentials")
 
-        # arches_connection object only exists on successful
+        self.assertEqual(self.dlg.tabWidget.currentIndex(), 1, "Logged-in tab should be current tab")
+        self.assertTrue(self.dlg.tabWidget.isTabVisible(1), "Logged-in tab should be visible")
+        self.assertFalse(self.dlg.tabWidget.isTabVisible(0), "Log-in tab should not be visible")
+            
+        # Logged-in tab display changes (when user has no fullname stored)
+        self.assertEqual(self.dlg.displayFullNameLabel.text(), "admin", "Full name label is username")
+        self.assertFalse(self.dlg.displayUsernameLabel.isVisible(), "Username label should be hidden")
+        self.assertFalse(self.dlg.displayUsernameFrame.isVisible(), "Username frame should be hidden")
+
+        # TODO: add tests for Create and Edit resource tab UIs once test layers are available in test Arches and QGIS instances


### PR DESCRIPTION
Testing the connection process and its effects is challenging, as the connection process is a subtask, that's added to the task manager indirectly within the `ArchesConnectionView`. 

Starting a full connection process by running `ArchesConnectionView.arches_connection_save` or even by simulating the login button being pressed, results in the test finishing without `ConnectionProcess.finished` ever being run, as the testing process is not running the QGIS Event loop, to constantly check for the completed run command. 

If initiating `ConnectionProcess.run` directly, however, then the result can be saved (preventing garbage collection), and then `finished()` can also be run manually using the result. This is the test currently called `test_changes_to_ui_after_connection` in `test_ui/test_connection.py`. The assertions all relate to the changes to the ui following a successful connection. 

To test the initial half of the login process, the second test checks that ConnectionProcess is successfully added to the task manager with the correct login credentials. Because we don't actually want the subtask to run (given the issue above), the task manager and its 'add_task' method have both been mocked. 

This second test could potentially be run from the point of pressing the login button, as was previously considered, but I think this signal link should probably be tested separately. 