### PR TITLE
Hyperlinks for URLs on successful create & edit resource messages 

### DIFF
--- a/arches_project/core/arches/resources.py
+++ b/arches_project/core/arches/resources.py
@@ -191,10 +191,6 @@ class ArchesResources:
                     edited_resource_url = f"{arches_api.arches_token['formatted_url']}/resource/{results['resourceinstance_id']}"
                     dlg.editResOutputBoxLabel.setText(
                         f'Successfully edited the selected resource with the selected geometry.<br>To continue editing the resource navigate to...<br><a href="{edited_resource_url}">{edited_resource_url}</a>'
-                        % (
-                            arches_api.arches_token["formatted_url"],
-                            results["resourceinstance_id"],
-                        )
                     )
                     show_message(
                         iface,

--- a/arches_project/core/arches/resources.py
+++ b/arches_project/core/arches/resources.py
@@ -88,13 +88,9 @@ class ArchesResources:
                         arches_operation="create",
                     )
                     dlg.createResOutputBoxFrame.show()
+                    created_resource_url = f"{arches_api.arches_token['formatted_url']}/resource/{results['resourceinstance_id']}"
                     dlg.createResOutputBoxLabel.setText(
-                        """Successfully created a new resource with the selected geometry.
-                                                        \nTo continue the creation of your new resource, navigate to...\n%s/resource/%s"""
-                        % (
-                            arches_api.arches_token["formatted_url"],
-                            results["resourceinstance_id"],
-                        )
+                        f'Successfully created a new resource with the selected geometry.<br>To continue the creation of your new resource, navigate to...<br><a href="{created_resource_url}">{created_resource_url}</a>'
                     )
                     show_message(
                         iface, "Success", "A new Arches resource has been created."
@@ -192,9 +188,9 @@ class ArchesResources:
                         arches_operation=operation_type,
                     )
                     dlg.editResOutputBoxFrame.show()
+                    edited_resource_url = f"{arches_api.arches_token['formatted_url']}/resource/{results['resourceinstance_id']}"
                     dlg.editResOutputBoxLabel.setText(
-                        """Successfully edited the selected resource with the selected geometry.
-                                                        \nTo continue editing the resource navigate to...\n%s/resource/%s"""
+                        f'Successfully edited the selected resource with the selected geometry.<br>To continue editing the resource navigate to...<br><a href="{edited_resource_url}">{edited_resource_url}</a>'
                         % (
                             arches_api.arches_token["formatted_url"],
                             results["resourceinstance_id"],

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -934,6 +934,9 @@
                    <property name="openExternalLinks">
                     <bool>true</bool>
                    </property>
+                   <property name="textInteractionFlags">
+                    <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
+                   </property>
                   </widget>
                  </item>
                 </layout>
@@ -1186,6 +1189,9 @@
                    </property>
                    <property name="openExternalLinks">
                     <bool>true</bool>
+                   </property>
+                   <property name="textInteractionFlags">
+                    <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
                    </property>
                   </widget>
                  </item>

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -161,7 +161,7 @@
       </font>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>3</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -721,7 +721,7 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-94</y>
+            <y>-82</y>
             <width>495</width>
             <height>554</height>
            </rect>
@@ -931,6 +931,9 @@
                    <property name="wordWrap">
                     <bool>true</bool>
                    </property>
+                   <property name="openExternalLinks">
+                    <bool>true</bool>
+                   </property>
                   </widget>
                  </item>
                 </layout>
@@ -975,7 +978,7 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>0</y>
+            <y>-220</y>
             <width>495</width>
             <height>680</height>
            </rect>
@@ -1179,6 +1182,9 @@
                     <string/>
                    </property>
                    <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                   <property name="openExternalLinks">
                     <bool>true</bool>
                    </property>
                   </widget>


### PR DESCRIPTION
Closes #85 

PyQt uses HTML syntax to link to a URL, hence the `<a>` tags. In addition, `<br>` needs to be used rather than `\n`.

