### PR TITLE
Fix refresh_token functionality 

### DIFF
--- a/arches_project/core/arches/resources.py
+++ b/arches_project/core/arches/resources.py
@@ -102,7 +102,7 @@ class ArchesResources:
                     dlg_resource_confirmation.close()
                 except:
                     dlg.createResOutputBoxFrame.show()
-                    dlg.createResOutputBox.setText("Resource creation FAILED.")
+                    dlg.createResOutputBoxLabel.setText("Resource creation FAILED.")
                     show_message(
                         iface, "Error", "Resource creation failed.", duration=-1
                     )

--- a/arches_project/core/utils/refresh_token.py
+++ b/arches_project/core/utils/refresh_token.py
@@ -9,7 +9,7 @@ def refresh_token():
     try:
         files = {
             "grant_type": (None, "refresh_token"),
-            "client_id": (None, arches_api.clientid),
+            "client_id": (None, arches_api.client_id),
             "refresh_token": (None, arches_api.arches_token["refresh_token"]),
         }
 


### PR DESCRIPTION
Rename `clientid` to `client_id` and `recreateResOutputBox` to `recreateResOutputBoxLabel`

Closes https://github.com/archesproject/arches-qgis/issues/121