### PR TITLE
Refactor: move reset & update functions into new (views) file 

### DIFF
--- a/arches_project/core/arches/connection.py
+++ b/arches_project/core/arches/connection.py
@@ -1,12 +1,16 @@
 import requests
 from datetime import datetime, timedelta
 
-from arches_project.core.views.login import LoggedIn
 from arches_project.core.views.components.qgis_messaging import show_message
 from arches_project.core.views.components.spinner import triggerSpinner
-from arches_project.core.views.components.login_autocomplete import (
-    load_saved_credentials,
+from arches_project.core.views.components.dialog_updates import connection_reset
+from arches_project.core.views.components.dialog_updates import (
+    update_create_resources_tab,
 )
+from arches_project.core.views.components.dialog_updates import (
+    update_edit_resources_tab,
+)
+from arches_project.core.views.components.dialog_updates import update_login_tab
 
 from arches_project.core.arches.api import arches_api
 
@@ -146,59 +150,6 @@ class ArchesConnection:
             pass
         return arches_graphs_list
 
-    def connection_reset(self, hard_reset, dlg, iface, manual_logout=False):
-        """
-        Reset Arches connection
-        """
-        # TODO: This is all UI related, so should be moved into views/
-        if hard_reset == True:
-            # Reset connection inputs
-            dlg.archesServerInput.setText("")
-            dlg.usernameInput.setText("")
-            dlg.passwordInput.setText("")
-            # Reset logged in values
-            dlg.displayFullNameLabel.setText("")
-            dlg.displayConnectionInfoLabel.setText("")
-            dlg.displayUsernameLabel.setText("")
-            # Replace login tab with logged in tab
-            dlg.tabWidget.setTabVisible(0, True)
-            dlg.tabWidget.setTabVisible(1, False)
-            dlg.tabWidget.setCurrentIndex(0)
-
-        # Reset stored data
-        arches_api.arches_user_info = {}
-        arches_api.arches_connection_cache = {}
-        arches_api.arches_token = {}
-        arches_api.arches_graphs_list = []
-        # Reset Create Resource tab as no longer useable
-        dlg.createResModelSelectCombo.setEnabled(False)
-        dlg.createResGeomSelectCombo.setEnabled(False)
-        dlg.createResButton.setEnabled(False)
-        dlg.createResOutputBoxLabel.setText("")
-        dlg.createResOutputBoxFrame.hide()
-        ## Set "Edit Resource" to false to begin with
-        dlg.editResAddGeom.setEnabled(False)
-        dlg.editResReplaceGeom.setEnabled(False)
-        dlg.editResGeomSelectCombo.setEnabled(False)
-        dlg.editResOutputBoxLabel.setText("")
-        dlg.editResOutputBoxFrame.hide()
-        dlg.editResSelectedResAttributeTable.setRowCount(0)
-        dlg.editResSelectedResAttributeTable.setEnabled(False)
-        dlg.editResSelectedResId.setText(
-            "Connect to your Arches instance to edit resources."
-        )
-        # Hide multiple nodegroup dropdown
-        dlg.createResNodeSelectCombo.setEnabled(False)
-        # Reload saved credentials for the autocompletes
-        load_saved_credentials(dlg)
-
-        if manual_logout:
-            show_message(
-                iface,
-                "information",
-                "Logged out of Arches instance. Please reconnect to use the plugin.",
-            )
-
     def store_auto_complete_credentials(self):
 
         saved_urls = QSettings().value("urls", [])
@@ -288,53 +239,6 @@ class ConnectionProcess(QgsTask):
 
     def finished(self, result):
 
-        def update_login_tab():
-            # Replace login tab with logged in tab
-            self.dlg.tabWidget.setTabVisible(0, False)
-            self.dlg.tabWidget.setTabVisible(1, True)
-            self.dlg.tabWidget.setCurrentIndex(1)
-
-            logged_in_tab = LoggedIn(
-                dlg=self.dlg,
-                username=self.username,
-                url=self.url,
-                arches_user_info=arches_api.arches_user_info,
-            )
-            logged_in_tab.update_logged_in_view()
-            # self.dlg.displayTextLabel.setText(f"Connected to {self.url} as {self.dlg.usernameInput.text()}.")
-            # self.dlg.displayUrlLabel.setOpenExternalLinks(True) #TODO
-
-        def update_create_resources_tab():
-            self.dlg.createResModelSelectCombo.clear()
-            self.dlg.createResGeomSelectCombo.setEnabled(True)
-            self.dlg.createResGeomSelectCombo.clear()
-            self.dlg.createResGeomSelectCombo.addItems(
-                [layer.name() for layer in arches_api.layers]
-            )
-
-            if arches_api.arches_graphs_list:
-                self.dlg.createResModelSelectCombo.setEnabled(True)
-                self.dlg.createResModelSelectCombo.addItems(
-                    [graph["name"] for graph in arches_api.arches_graphs_list]
-                )
-                self.dlg.createResButton.setEnabled(True)
-
-        def update_edit_resources_tab():
-            self.dlg.editResAddGeom.setEnabled(False)
-            self.dlg.editResReplaceGeom.setEnabled(False)
-            if arches_api.arches_selected_resource["resourceinstanceid"]:
-                self.dlg.editResAddGeom.setEnabled(True)
-                self.dlg.editResReplaceGeom.setEnabled(True)
-            self.dlg.editResGeomSelectCombo.setEnabled(True)
-            self.dlg.editResGeomSelectCombo.clear()
-            self.dlg.editResGeomSelectCombo.addItems(
-                [layer.name() for layer in arches_api.layers]
-            )
-            self.dlg.editResSelectedResAttributeTable.setEnabled(True)
-            self.dlg.editResSelectedResId.setText(
-                "Connected to Arches. Select an Arches resource to proceed."
-            )
-
         triggerSpinner(dlg=self.dlg, plugin_dir=self.plugin_dir).hide_spinner()
 
         if result:
@@ -351,13 +255,11 @@ class ConnectionProcess(QgsTask):
                 ]
 
                 self.arches_connection.store_auto_complete_credentials()
-                update_login_tab()
-                update_edit_resources_tab()
-                update_create_resources_tab()
+                update_login_tab(dlg=self.dlg, username=self.username, url=self.url)
+                update_edit_resources_tab(dlg=self.dlg)
+                update_create_resources_tab(dlg=self.dlg)
             else:
-                ArchesConnection(None, None, None).connection_reset(
-                    hard_reset=True, dlg=self.dlg, iface=self.iface
-                )
+                connection_reset(hard_reset=True, dlg=self.dlg, iface=self.iface)
                 show_message(
                     self.iface,
                     "Warning",
@@ -381,9 +283,7 @@ class ConnectionProcess(QgsTask):
             self.dlg.loginErrorMessageLabel.setText(
                 "Failed to connect to Arches instance."
             )
-            ArchesConnection(None, None, None).connection_reset(
-                hard_reset=True, dlg=self.dlg, iface=self.iface
-            )
+            connection_reset(hard_reset=True, dlg=self.dlg, iface=self.iface)
 
     def cancel(self):
         triggerSpinner(dlg=self.dlg, plugin_dir=self.plugin_dir).hide_spinner()

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -1,0 +1,104 @@
+from arches_project.core.views.components.qgis_messaging import show_message
+from arches_project.core.views.components.login_autocomplete import (
+    load_saved_credentials,
+)
+from arches_project.core.views.login import LoggedIn
+
+from arches_project.core.arches.api import arches_api
+
+
+def connection_reset(hard_reset, dlg, iface, manual_logout=False):
+    """
+    Reset Arches connection
+    """
+    # TODO: This is all UI related, so should be moved into views/
+    if hard_reset == True:
+        # Reset connection inputs
+        dlg.archesServerInput.setText("")
+        dlg.usernameInput.setText("")
+        dlg.passwordInput.setText("")
+        # Reset logged in values
+        dlg.displayFullNameLabel.setText("")
+        dlg.displayConnectionInfoLabel.setText("")
+        dlg.displayUsernameLabel.setText("")
+        # Replace login tab with logged in tab
+        dlg.tabWidget.setTabVisible(0, True)
+        dlg.tabWidget.setTabVisible(1, False)
+        dlg.tabWidget.setCurrentIndex(0)
+
+    # Reset stored data
+    arches_api.arches_user_info = {}
+    arches_api.arches_connection_cache = {}
+    arches_api.arches_token = {}
+    arches_api.arches_graphs_list = []
+    # Reset Create Resource tab as no longer useable
+    dlg.createResModelSelectCombo.setEnabled(False)
+    dlg.createResGeomSelectCombo.setEnabled(False)
+    dlg.createResButton.setEnabled(False)
+    dlg.createResOutputBoxLabel.setText("")
+    dlg.createResOutputBoxFrame.hide()
+    ## Set "Edit Resource" to false to begin with
+    dlg.editResAddGeom.setEnabled(False)
+    dlg.editResReplaceGeom.setEnabled(False)
+    dlg.editResGeomSelectCombo.setEnabled(False)
+    dlg.editResOutputBoxLabel.setText("")
+    dlg.editResOutputBoxFrame.hide()
+    dlg.editResSelectedResAttributeTable.setRowCount(0)
+    dlg.editResSelectedResAttributeTable.setEnabled(False)
+    dlg.editResSelectedResId.setText(
+        "Connect to your Arches instance to edit resources."
+    )
+    # Hide multiple nodegroup dropdown
+    dlg.createResNodeSelectCombo.setEnabled(False)
+    # Reload saved credentials for the autocompletes
+    load_saved_credentials(dlg)
+
+    if manual_logout:
+        show_message(
+            iface,
+            "information",
+            "Logged out of Arches instance. Please reconnect to use the plugin.",
+        )
+
+
+def update_login_tab(dlg, username, url):
+    """
+    Run the two functions from LoggedIn to update the tabs
+    """
+    logged_in_tab = LoggedIn(
+        dlg=dlg,
+        username=username,
+        url=url,
+        arches_user_info=arches_api.arches_user_info,
+    )
+    logged_in_tab.update_logged_in_view()
+    logged_in_tab.hide_login_tab()
+
+
+def update_create_resources_tab(dlg):
+    dlg.createResModelSelectCombo.clear()
+    dlg.createResGeomSelectCombo.setEnabled(True)
+    dlg.createResGeomSelectCombo.clear()
+    dlg.createResGeomSelectCombo.addItems([layer.name() for layer in arches_api.layers])
+
+    if arches_api.arches_graphs_list:
+        dlg.createResModelSelectCombo.setEnabled(True)
+        dlg.createResModelSelectCombo.addItems(
+            [graph["name"] for graph in arches_api.arches_graphs_list]
+        )
+        dlg.createResButton.setEnabled(True)
+
+
+def update_edit_resources_tab(dlg):
+    dlg.editResAddGeom.setEnabled(False)
+    dlg.editResReplaceGeom.setEnabled(False)
+    if arches_api.arches_selected_resource["resourceinstanceid"]:
+        dlg.editResAddGeom.setEnabled(True)
+        dlg.editResReplaceGeom.setEnabled(True)
+    dlg.editResGeomSelectCombo.setEnabled(True)
+    dlg.editResGeomSelectCombo.clear()
+    dlg.editResGeomSelectCombo.addItems([layer.name() for layer in arches_api.layers])
+    dlg.editResSelectedResAttributeTable.setEnabled(True)
+    dlg.editResSelectedResId.setText(
+        "Connected to Arches. Select an Arches resource to proceed."
+    )

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -11,7 +11,6 @@ def connection_reset(hard_reset, dlg, iface, manual_logout=False):
     """
     Reset Arches connection
     """
-    # TODO: This is all UI related, so should be moved into views/
     if hard_reset == True:
         # Reset connection inputs
         dlg.archesServerInput.setText("")

--- a/arches_project/core/views/connection.py
+++ b/arches_project/core/views/connection.py
@@ -1,7 +1,6 @@
 from arches_project.core.arches.connection import ConnectionProcess
 from arches_project.core.views.components.missing_credentials import missing_credentials
-from arches_project.core.views.login import UpdateLogin
-from arches_project.core.views.login import UpdateLogin
+from arches_project.core.views.login import UpdateLoginProgress
 from arches_project.core.utils.format_url import format_url
 from arches_project.core.views.components.spinner import triggerSpinner
 
@@ -75,8 +74,10 @@ class ArchesConnectionView:
                 iface=self.iface,
                 plugin_dir=self.plugin_dir,
             )
-            self.login_text_updater = UpdateLogin(self.dlg.updateText)
-            self.login_percent_updater = UpdateLogin(self.dlg.percentProgressText)
+            self.login_text_updater = UpdateLoginProgress(self.dlg.updateText)
+            self.login_percent_updater = UpdateLoginProgress(
+                self.dlg.percentProgressText
+            )
             self.dlg.updateText.setText("")
             self.dlg.percentProgressText.setText("0%")
             self.arches_connection.login_updates.connect(

--- a/arches_project/core/views/login.py
+++ b/arches_project/core/views/login.py
@@ -12,6 +12,9 @@ class LoggedIn:
         self.url = url
 
     def update_logged_in_view(self):
+        """
+        Update the "logged in" tab one logged in
+        """
         full_name = ""
         if arches_api.arches_user_info["first_name"]:
             full_name = f'{arches_api.arches_user_info["first_name"]} {arches_api.arches_user_info["last_name"]}'
@@ -26,6 +29,14 @@ class LoggedIn:
             self.dlg.displayUsernameLabel.setText(self.username)
 
         self.dlg.displayConnectionInfoLabel.setText(f"You are connected to {self.url}.")
+
+    def hide_login_tab(self):
+        """
+        Hide the login tab and reveal the logged in/user profile tab
+        """
+        self.dlg.tabWidget.setTabVisible(0, False)
+        self.dlg.tabWidget.setTabVisible(1, True)
+        self.dlg.tabWidget.setCurrentIndex(1)
 
 
 class UpdateLoginProgress:

--- a/arches_project/core/views/login.py
+++ b/arches_project/core/views/login.py
@@ -28,7 +28,7 @@ class LoggedIn:
         self.dlg.displayConnectionInfoLabel.setText(f"You are connected to {self.url}.")
 
 
-class UpdateLogin:
+class UpdateLoginProgress:
     def __init__(self, dlg_label, step=0):
         self.updateTextLabel = dlg_label
         self.total_number_steps = 4

--- a/arches_project/ui/arches_project_dialog.py
+++ b/arches_project/ui/arches_project_dialog.py
@@ -35,6 +35,7 @@ from arches_project.core.views.components.psql_layers import show_hide_psql_laye
 from arches_project.core.views.components.multiple_graph_nodes import (
     multiple_geometry_node_check,
 )
+from arches_project.core.views.components.dialog_updates import connection_reset
 from arches_project.core.views.resources import ResourcesView
 from arches_project.core.views.connection import ArchesConnectionView
 
@@ -122,7 +123,7 @@ class ArchesProjectDialog(QtWidgets.QDialog, FORM_CLASS):
         self.btnConnect.clicked.connect(self.arches_connection.arches_connection_save)
         self.btnLogout.clicked.connect(
             partial(
-                ArchesConnection(None, None, None).connection_reset,
+                connection_reset,
                 hard_reset=True,
                 dlg=self,
                 iface=self.iface,


### PR DESCRIPTION
Previously the functions for `connection_reset`, `update_login_tab`, `update_create_resources_tab` and `update_edit_resources_tab` all lived in the Arches Connection core file (backend) despite only used to control updates to the frontend `dlg`. Moving these functions out into a file in views/components makes the most sense, and I have not bundled them into a method with the reasoning that they will be called as helper functions.

The created file is called `dialog_updates` which may not be the best name so I'm open to suggestions, but it needs to convey that the functions are primarily for big updates to the UI (i.e. when a user is authenticated) or a major reset (i.e. when the user cancels or logs out and all needs to be cleared and disabled).