### PR TITLE
Fix duplicating nodes in node select dropdown

### DIFF
--- a/arches_project/core/views/components/multiple_graph_nodes.py
+++ b/arches_project/core/views/components/multiple_graph_nodes.py
@@ -7,6 +7,7 @@ def multiple_geometry_node_check(dlg):
 
     dlg.createResNodeSelectCombo.setEnabled(False)
     dlg.createResNodeSelectFrame.hide()
+    arches_api.geometry_nodes = []
 
     if selectedGraph:
         if selectedGraph["multiple_geometry_nodes"] == True:


### PR DESCRIPTION
Clear `arches_api.geometry_nodes` at the start of `multiple_geometry_node_check`, before repopulating. Ensures that nodes don't duplicate if the function is run several times, for example changing between different models on the Create Resource tab. 

Closes https://github.com/archesproject/arches-qgis/issues/129