### PR TITLE
Add activity log tab

### DIFF
--- a/arches_project/core/arches/resources.py
+++ b/arches_project/core/arches/resources.py
@@ -204,7 +204,7 @@ class ArchesResources:
                         "Success",
                         f"Resource geometry {operation_type} was successful.",
                     )
-                    action = (
+                    action_description = (
                         "Appended feature(s)"
                         if operation_type == "append"
                         else "Replaced feature(s)"
@@ -212,7 +212,7 @@ class ArchesResources:
 
                     update_activity_log(
                         dlg,
-                        action,
+                        action_description,
                         edited_resource_url,
                         results["resourceinstance_id"],
                     )

--- a/arches_project/core/arches/resources.py
+++ b/arches_project/core/arches/resources.py
@@ -204,6 +204,18 @@ class ArchesResources:
                         "Success",
                         f"Resource geometry {operation_type} was successful.",
                     )
+                    action = (
+                        "Append feature(s)"
+                        if operation_type == "append"
+                        else "Replace feature(s)"
+                    )
+
+                    update_activity_log(
+                        dlg,
+                        action,
+                        edited_resource_url,
+                        results["resourceinstance_id"],
+                    )
                     dialog.close()
                 except:
                     dlg.editResOutputBoxFrame.show()

--- a/arches_project/core/arches/resources.py
+++ b/arches_project/core/arches/resources.py
@@ -95,6 +95,12 @@ class ArchesResources:
                     show_message(
                         iface, "Success", "A new Arches resource has been created."
                     )
+
+                    dlg.logTextEdit.append("Resource Created ")
+                    dlg.logTextEdit.append(str(datetime.now()))
+                    dlg.logTextEdit.append(
+                        f"<a href='{created_resource_url}'>{results['resourceinstance_id']}</a><br>"
+                    )
                     dlg_resource_confirmation.close()
                 except:
                     dlg.createResOutputBoxFrame.show()

--- a/arches_project/core/arches/resources.py
+++ b/arches_project/core/arches/resources.py
@@ -4,10 +4,9 @@ from functools import partial
 
 from arches_project.core.utils.geometry_conversion import Geometries
 from arches_project.core.views.components.qgis_messaging import show_message
+from arches_project.core.views.components.dialog_updates import update_activity_log
 from arches_project.core.utils.refresh_token import refresh_token
 from arches_project.core.arches.api import arches_api
-from qgis.PyQt.QtWidgets import QTableWidgetItem, QLabel
-from PyQt5.QtCore import Qt
 
 
 class ArchesResources:
@@ -94,36 +93,15 @@ class ArchesResources:
                     dlg.createResOutputBoxLabel.setText(
                         f'Successfully created a new resource with the selected geometry.<br>To continue the creation of your new resource, navigate to...<br><a href="{created_resource_url}">{created_resource_url}</a>'
                     )
+                    update_activity_log(
+                        dlg,
+                        "Created resource",
+                        created_resource_url,
+                        results["resourceinstance_id"],
+                    )
                     show_message(
                         iface, "Success", "A new Arches resource has been created."
                     )
-
-                    try:
-                        resource_link = f"<a href='{created_resource_url}'>{results['resourceinstance_id']}</a>"
-                        link_label = QLabel(resource_link)
-                        link_label.setOpenExternalLinks(True)
-
-                        row_count = dlg.logTable.rowCount()
-                        dlg.logTable.insertRow(row_count)
-
-                        action_task_widget = QTableWidgetItem("Created resource")
-                        action_task_widget.setTextAlignment(
-                            Qt.AlignCenter | Qt.AlignVCenter
-                        )
-
-                        action_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                        action_datetime_widget = QTableWidgetItem(action_datetime)
-                        action_datetime_widget.setTextAlignment(
-                            Qt.AlignCenter | Qt.AlignVCenter
-                        )
-
-                        dlg.logTable.setItem(row_count, 0, action_task_widget)
-                        dlg.logTable.setItem(row_count, 1, action_datetime_widget)
-                        dlg.logTable.setCellWidget(row_count, 2, link_label)
-
-                    except Exception as e:
-                        print("Error", e)
-
                     dlg_resource_confirmation.close()
                 except:
                     dlg.createResOutputBoxFrame.show()

--- a/arches_project/core/arches/resources.py
+++ b/arches_project/core/arches/resources.py
@@ -205,9 +205,9 @@ class ArchesResources:
                         f"Resource geometry {operation_type} was successful.",
                     )
                     action = (
-                        "Append feature(s)"
+                        "Appended feature(s)"
                         if operation_type == "append"
-                        else "Replace feature(s)"
+                        else "Replaced feature(s)"
                     )
 
                     update_activity_log(

--- a/arches_project/core/arches/resources.py
+++ b/arches_project/core/arches/resources.py
@@ -6,6 +6,8 @@ from arches_project.core.utils.geometry_conversion import Geometries
 from arches_project.core.views.components.qgis_messaging import show_message
 from arches_project.core.utils.refresh_token import refresh_token
 from arches_project.core.arches.api import arches_api
+from qgis.PyQt.QtWidgets import QTableWidgetItem, QLabel
+from PyQt5.QtCore import Qt
 
 
 class ArchesResources:
@@ -96,11 +98,32 @@ class ArchesResources:
                         iface, "Success", "A new Arches resource has been created."
                     )
 
-                    dlg.logTextEdit.append("Resource Created ")
-                    dlg.logTextEdit.append(str(datetime.now()))
-                    dlg.logTextEdit.append(
-                        f"<a href='{created_resource_url}'>{results['resourceinstance_id']}</a><br>"
-                    )
+                    try:
+                        resource_link = f"<a href='{created_resource_url}'>{results['resourceinstance_id']}</a>"
+                        link_label = QLabel(resource_link)
+                        link_label.setOpenExternalLinks(True)
+
+                        row_count = dlg.logTable.rowCount()
+                        dlg.logTable.insertRow(row_count)
+
+                        action_task_widget = QTableWidgetItem("Created resource")
+                        action_task_widget.setTextAlignment(
+                            Qt.AlignCenter | Qt.AlignVCenter
+                        )
+
+                        action_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                        action_datetime_widget = QTableWidgetItem(action_datetime)
+                        action_datetime_widget.setTextAlignment(
+                            Qt.AlignCenter | Qt.AlignVCenter
+                        )
+
+                        dlg.logTable.setItem(row_count, 0, action_task_widget)
+                        dlg.logTable.setItem(row_count, 1, action_datetime_widget)
+                        dlg.logTable.setCellWidget(row_count, 2, link_label)
+
+                    except Exception as e:
+                        print("Error", e)
+
                     dlg_resource_confirmation.close()
                 except:
                     dlg.createResOutputBoxFrame.show()

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -41,8 +41,6 @@ def connection_reset(hard_reset, dlg, iface, manual_logout=False):
             dlg.usernameInput.setText("")
             dlg.passwordInput.setText("")
 
-            dlg.activityLogTable.setRowCount(0)
-
     # Reset Create Resource tab as no longer useable
     dlg.createResModelSelectCombo.setEnabled(False)
     dlg.createResGeomSelectCombo.setEnabled(False)

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -156,24 +156,21 @@ def reset_refresh_btn(dlg):
         )
     )
 def update_activity_log(dlg, action, resource_url, resourceinstance_id):
-    try:
-        resource_link = f"<a href='{resource_url}'>{resourceinstance_id}</a>"
-        link_label = QLabel(resource_link)
-        link_label.setOpenExternalLinks(True)
+    resource_link = f"<a href='{resource_url}'>{resourceinstance_id}</a>"
+    link_label = QLabel(resource_link)
+    link_label.setOpenExternalLinks(True)
 
-        dlg.activityLogTable.insertRow(0)
+    dlg.activityLogTable.insertRow(0)
 
-        action_task_widget = QTableWidgetItem(action)
-        action_task_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
+    action_task_widget = QTableWidgetItem(action)
+    action_task_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
 
-        action_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        action_datetime_widget = QTableWidgetItem(action_datetime)
-        action_datetime_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
+    action_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    action_datetime_widget = QTableWidgetItem(action_datetime)
+    action_datetime_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
 
-        dlg.activityLogTable.setItem(0, 0, action_task_widget)
-        dlg.activityLogTable.setItem(0, 1, action_datetime_widget)
-        dlg.activityLogTable.setCellWidget(0, 2, link_label)
+    dlg.activityLogTable.setItem(0, 0, action_task_widget)
+    dlg.activityLogTable.setItem(0, 1, action_datetime_widget)
+    dlg.activityLogTable.setCellWidget(0, 2, link_label)
 
-        dlg.activityLogTable.scrollToTop()
-    except Exception as e:
-        print(e)
+    dlg.activityLogTable.scrollToTop()

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -161,7 +161,7 @@ def update_activity_log(dlg, action, resource_url, resourceinstance_id):
         link_label = QLabel(resource_link)
         link_label.setOpenExternalLinks(True)
 
-        dlg.logTable.insertRow(0)
+        dlg.activityLogTable.insertRow(0)
 
         action_task_widget = QTableWidgetItem(action)
         action_task_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
@@ -170,10 +170,10 @@ def update_activity_log(dlg, action, resource_url, resourceinstance_id):
         action_datetime_widget = QTableWidgetItem(action_datetime)
         action_datetime_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
 
-        dlg.logTable.setItem(0, 0, action_task_widget)
-        dlg.logTable.setItem(0, 1, action_datetime_widget)
-        dlg.logTable.setCellWidget(0, 2, link_label)
+        dlg.activityLogTable.setItem(0, 0, action_task_widget)
+        dlg.activityLogTable.setItem(0, 1, action_datetime_widget)
+        dlg.activityLogTable.setCellWidget(0, 2, link_label)
 
-        dlg.logTable.scrollToTop()
+        dlg.activityLogTable.scrollToTop()
     except Exception as e:
         print(e)

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -4,6 +4,9 @@ from arches_project.core.views.components.login_autocomplete import (
 )
 from arches_project.core.views.login import LoggedIn
 from arches_project.core.arches.api import arches_api
+from qgis.PyQt.QtWidgets import QTableWidgetItem, QLabel
+from PyQt5.QtCore import Qt
+from datetime import datetime
 
 from PyQt5.QtCore import QTimer, QPropertyAnimation, QEasingCurve
 from qgis.PyQt.QtGui import QIcon
@@ -152,3 +155,24 @@ def reset_refresh_btn(dlg):
             os.path.join(dlg.plugin_dir, "icons", "arrows-rotate-solid-full-white.svg")
         )
     )
+def update_activity_log(dlg, action, resource_url, resourceinstance_id):
+    try:
+        resource_link = f"<a href='{resource_url}'>{resourceinstance_id}</a>"
+        link_label = QLabel(resource_link)
+        link_label.setOpenExternalLinks(True)
+
+        row_count = dlg.logTable.rowCount()
+        dlg.logTable.insertRow(row_count)
+
+        action_task_widget = QTableWidgetItem(action)
+        action_task_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
+
+        action_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        action_datetime_widget = QTableWidgetItem(action_datetime)
+        action_datetime_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
+
+        dlg.logTable.setItem(row_count, 0, action_task_widget)
+        dlg.logTable.setItem(row_count, 1, action_datetime_widget)
+        dlg.logTable.setCellWidget(row_count, 2, link_label)
+    except Exception as e:
+        print(e)

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -156,14 +156,14 @@ def reset_refresh_btn(dlg):
     )
 
 
-def update_activity_log(dlg, action, resource_url, resourceinstance_id):
+def update_activity_log(dlg, action_description, resource_url, resourceinstance_id):
     resource_link = f"<a href='{resource_url}'>{resourceinstance_id}</a>"
     link_label = QLabel(resource_link)
     link_label.setOpenExternalLinks(True)
 
     dlg.activityLogTable.insertRow(0)
 
-    action_task_widget = QTableWidgetItem(action)
+    action_task_widget = QTableWidgetItem(action_description)
     action_task_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
 
     action_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -12,7 +12,6 @@ from PyQt5.QtCore import QTimer, QPropertyAnimation, QEasingCurve
 from qgis.PyQt.QtGui import QIcon
 
 import os
-import datetime
 
 
 def connection_reset(hard_reset, dlg, iface, manual_logout=False):
@@ -155,6 +154,8 @@ def reset_refresh_btn(dlg):
             os.path.join(dlg.plugin_dir, "icons", "arrows-rotate-solid-full-white.svg")
         )
     )
+
+
 def update_activity_log(dlg, action, resource_url, resourceinstance_id):
     resource_link = f"<a href='{resource_url}'>{resourceinstance_id}</a>"
     link_label = QLabel(resource_link)

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -6,7 +6,7 @@ from arches_project.core.views.login import LoggedIn
 from arches_project.core.arches.api import arches_api
 from qgis.PyQt.QtWidgets import QTableWidgetItem, QLabel
 from PyQt5.QtCore import Qt
-from datetime import datetime
+import datetime
 
 from PyQt5.QtCore import QTimer, QPropertyAnimation, QEasingCurve
 from qgis.PyQt.QtGui import QIcon
@@ -168,7 +168,7 @@ def update_activity_log(dlg, action_description, resource_url, resourceinstance_
     action_task_widget = QTableWidgetItem(action_description)
     action_task_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
 
-    action_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    action_datetime = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     action_datetime_widget = QTableWidgetItem(action_datetime)
     action_datetime_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
 

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -160,6 +160,7 @@ def update_activity_log(dlg, action_description, resource_url, resourceinstance_
     resource_link = f"<a href='{resource_url}'>{resourceinstance_id}</a>"
     link_label = QLabel(resource_link)
     link_label.setOpenExternalLinks(True)
+    link_label.setAlignment(Qt.AlignCenter)
 
     dlg.activityLogTable.insertRow(0)
 

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -161,8 +161,7 @@ def update_activity_log(dlg, action, resource_url, resourceinstance_id):
         link_label = QLabel(resource_link)
         link_label.setOpenExternalLinks(True)
 
-        row_count = dlg.logTable.rowCount()
-        dlg.logTable.insertRow(row_count)
+        dlg.logTable.insertRow(0)
 
         action_task_widget = QTableWidgetItem(action)
         action_task_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
@@ -171,8 +170,10 @@ def update_activity_log(dlg, action, resource_url, resourceinstance_id):
         action_datetime_widget = QTableWidgetItem(action_datetime)
         action_datetime_widget.setTextAlignment(Qt.AlignCenter | Qt.AlignVCenter)
 
-        dlg.logTable.setItem(row_count, 0, action_task_widget)
-        dlg.logTable.setItem(row_count, 1, action_datetime_widget)
-        dlg.logTable.setCellWidget(row_count, 2, link_label)
+        dlg.logTable.setItem(0, 0, action_task_widget)
+        dlg.logTable.setItem(0, 1, action_datetime_widget)
+        dlg.logTable.setCellWidget(0, 2, link_label)
+
+        dlg.logTable.scrollToTop()
     except Exception as e:
         print(e)

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -35,11 +35,13 @@ def connection_reset(hard_reset, dlg, iface, manual_logout=False):
         load_saved_credentials(dlg)
         # Return to login page
         dlg.tabWidget.setCurrentIndex(0)
-        # Reset connection inputs
+        # Reset connection inputs and activity
         if manual_logout == True:
             dlg.archesServerInput.setText("")
             dlg.usernameInput.setText("")
             dlg.passwordInput.setText("")
+
+            dlg.activityLogTable.setRowCount(0)
 
     # Reset Create Resource tab as no longer useable
     dlg.createResModelSelectCombo.setEnabled(False)

--- a/arches_project/core/views/logging.py
+++ b/arches_project/core/views/logging.py
@@ -1,9 +1,0 @@
-def enable_logging(self):
-    if self.dlg.enableLoggingCheckbox.isChecked():
-        self.dlg.tabWidget.setTabVisible(5, True)
-
-    elif not self.dlg.enableLoggingCheckbox.isChecked():
-        self.dlg.tabWidget.setTabVisible(5, False)
-
-
-# TODO needs expanding into class and functionality

--- a/arches_project/core/views/login.py
+++ b/arches_project/core/views/login.py
@@ -36,7 +36,6 @@ class LoggedIn:
         """
         self.dlg.tabWidget.setTabVisible(0, False)
         self.dlg.tabWidget.setTabVisible(1, True)
-        self.dlg.tabWidget.setTabVisible(4, True)
         self.dlg.tabWidget.setCurrentIndex(1)
 
 

--- a/arches_project/core/views/login.py
+++ b/arches_project/core/views/login.py
@@ -36,7 +36,7 @@ class LoggedIn:
         """
         self.dlg.tabWidget.setTabVisible(0, False)
         self.dlg.tabWidget.setTabVisible(1, True)
-        self.dlg.tabWidget.setTabVisible(5, True)
+        self.dlg.tabWidget.setTabVisible(4, True)
         self.dlg.tabWidget.setCurrentIndex(1)
 
 

--- a/arches_project/core/views/login.py
+++ b/arches_project/core/views/login.py
@@ -36,6 +36,7 @@ class LoggedIn:
         """
         self.dlg.tabWidget.setTabVisible(0, False)
         self.dlg.tabWidget.setTabVisible(1, True)
+        self.dlg.tabWidget.setTabVisible(5, True)
         self.dlg.tabWidget.setCurrentIndex(1)
 
 

--- a/arches_project/core/views/stylesheets/arches.py
+++ b/arches_project/core/views/stylesheets/arches.py
@@ -132,7 +132,7 @@ class ArchesStylesheet:
             self.dlg.tabWidget.setTabText(3, "")
 
             self.dlg.tabWidget.setTabIcon(
-                4,
+                5,
                 QIcon(
                     QPixmap(
                         os.path.join(self.plugin_dir, "icons", "fa-cog.svg")
@@ -140,10 +140,10 @@ class ArchesStylesheet:
                 ),
             )
             self.dlg.tabWidget.setIconSize(QSize(16, 16))
-            self.dlg.tabWidget.setTabText(4, "")
+            self.dlg.tabWidget.setTabText(5, "")
 
             self.dlg.tabWidget.setTabIcon(
-                5,
+                4,
                 QIcon(
                     QPixmap(
                         os.path.join(self.plugin_dir, "icons", "ti-ticket.svg")
@@ -151,7 +151,7 @@ class ArchesStylesheet:
                 ),
             )
             self.dlg.tabWidget.setIconSize(QSize(16, 16))
-            self.dlg.tabWidget.setTabText(5, "")
+            self.dlg.tabWidget.setTabText(4, "")
 
             self.dlg.userProfileLabel.setFixedSize(80, 80)
             self.dlg.userProfileLabel.setPixmap(

--- a/arches_project/core/views/stylesheets/default.py
+++ b/arches_project/core/views/stylesheets/default.py
@@ -34,6 +34,6 @@ class DefaultStylesheet:
         self.dlg.tabWidget.setTabIcon(3, QIcon(""))
         self.dlg.tabWidget.setTabText(3, "Edit Resource")
         self.dlg.tabWidget.setTabIcon(4, QIcon(""))
-        self.dlg.tabWidget.setTabText(4, "Settings")
+        self.dlg.tabWidget.setTabText(4, "Log")
         self.dlg.tabWidget.setTabIcon(5, QIcon(""))
-        self.dlg.tabWidget.setTabText(5, "Log")
+        self.dlg.tabWidget.setTabText(5, "Settings")

--- a/arches_project/stylesheets/arches_styling.qss
+++ b/arches_project/stylesheets/arches_styling.qss
@@ -215,3 +215,8 @@ QLabel#userProfileLabel {
     border-radius: 40px;
     background-color: #d4d4d4;
 }
+
+QTableWidget::item {
+    padding-left: 10px;
+    padding-right: 10px;
+}

--- a/arches_project/stylesheets/arches_styling.qss
+++ b/arches_project/stylesheets/arches_styling.qss
@@ -25,7 +25,7 @@ QLabel#loginSuccessLabel,
 QLabel#createResTitleText, 
 QLabel#editResTitleLabel,
 QLabel#settingsTitleLabel,
-QLabel#logTitleLabel {
+QLabel#activityLogTitleLabel {
     font-size: 30px;
     font-weight: 400;
 }

--- a/arches_project/stylesheets/arches_styling.qss
+++ b/arches_project/stylesheets/arches_styling.qss
@@ -34,6 +34,7 @@ QLabel#signInDescriptionLabel,
 QLabel#displayTextLabel, 
 QLabel#createResDescriptionLabel, 
 QLabel#editResDescriptionLabel,
+QLabel#activityLogDescriptionLabel,
 QLabel#settingsDescriptionLabel {
     font-size: 16px;
     font-weight: 400;

--- a/arches_project/stylesheets/arches_styling.qss
+++ b/arches_project/stylesheets/arches_styling.qss
@@ -24,7 +24,8 @@ QLabel#signInLabel,
 QLabel#loginSuccessLabel, 
 QLabel#createResTitleText, 
 QLabel#editResTitleLabel,
-QLabel#settingsTitleLabel {
+QLabel#settingsTitleLabel,
+QLabel#logTitleLabel {
     font-size: 30px;
     font-weight: 400;
 }

--- a/arches_project/ui/arches_project_dialog.py
+++ b/arches_project/ui/arches_project_dialog.py
@@ -73,7 +73,6 @@ class ArchesProjectDialog(QtWidgets.QDialog, FORM_CLASS):
         # Set tab index to 0 always
         self.tabWidget.setCurrentIndex(0)
         self.tabWidget.setTabVisible(1, False)
-        self.tabWidget.setTabVisible(4, False)
 
         # to run when layer is changed in create resource and edit resource tabs
         self.hidePostgresLayers.setChecked(True)

--- a/arches_project/ui/arches_project_dialog.py
+++ b/arches_project/ui/arches_project_dialog.py
@@ -25,7 +25,6 @@
 import os
 from functools import partial
 
-from arches_project.core.views.logging import enable_logging
 from arches_project.core.views.components.login_autocomplete import (
     load_saved_credentials,
 )
@@ -75,8 +74,6 @@ class ArchesProjectDialog(QtWidgets.QDialog, FORM_CLASS):
         self.tabWidget.setCurrentIndex(0)
         self.tabWidget.setTabVisible(1, False)
         self.tabWidget.setTabVisible(5, False)
-
-        self.enableLoggingCheckbox.stateChanged.connect(enable_logging)
 
         # to run when layer is changed in create resource and edit resource tabs
         self.hidePostgresLayers.setChecked(True)

--- a/arches_project/ui/arches_project_dialog.py
+++ b/arches_project/ui/arches_project_dialog.py
@@ -73,7 +73,7 @@ class ArchesProjectDialog(QtWidgets.QDialog, FORM_CLASS):
         # Set tab index to 0 always
         self.tabWidget.setCurrentIndex(0)
         self.tabWidget.setTabVisible(1, False)
-        self.tabWidget.setTabVisible(5, False)
+        self.tabWidget.setTabVisible(4, False)
 
         # to run when layer is changed in create resource and edit resource tabs
         self.hidePostgresLayers.setChecked(True)

--- a/arches_project/ui/arches_project_dialog.py
+++ b/arches_project/ui/arches_project_dialog.py
@@ -185,4 +185,4 @@ class ArchesProjectDialog(QtWidgets.QDialog, FORM_CLASS):
         # set initial log table widths
         self.activityLogTable.setColumnWidth(0, 110)
         self.activityLogTable.setColumnWidth(1, 125)
-        self.activityLogTable.setColumnWidth(2, 300)
+        self.activityLogTable.horizontalHeader().setStretchLastSection(True)

--- a/arches_project/ui/arches_project_dialog.py
+++ b/arches_project/ui/arches_project_dialog.py
@@ -183,6 +183,6 @@ class ArchesProjectDialog(QtWidgets.QDialog, FORM_CLASS):
         self.opacity_effect = QGraphicsOpacityEffect(self.refreshConfirmLabel)
         self.refreshConfirmLabel.setGraphicsEffect(self.opacity_effect)
         # set initial log table widths
-        self.activityLogTable.setColumnWidth(0, 110)
-        self.activityLogTable.setColumnWidth(1, 125)
+        self.activityLogTable.setColumnWidth(0, 100)
+        self.activityLogTable.setColumnWidth(1, 100)
         self.activityLogTable.horizontalHeader().setStretchLastSection(True)

--- a/arches_project/ui/arches_project_dialog.py
+++ b/arches_project/ui/arches_project_dialog.py
@@ -185,3 +185,7 @@ class ArchesProjectDialog(QtWidgets.QDialog, FORM_CLASS):
 
         self.opacity_effect = QGraphicsOpacityEffect(self.refreshConfirmLabel)
         self.refreshConfirmLabel.setGraphicsEffect(self.opacity_effect)
+        # set initial log table widths
+        self.logTable.setColumnWidth(0, 110)
+        self.logTable.setColumnWidth(1, 125)
+        self.logTable.setColumnWidth(2, 300)

--- a/arches_project/ui/arches_project_dialog.py
+++ b/arches_project/ui/arches_project_dialog.py
@@ -183,6 +183,6 @@ class ArchesProjectDialog(QtWidgets.QDialog, FORM_CLASS):
         self.opacity_effect = QGraphicsOpacityEffect(self.refreshConfirmLabel)
         self.refreshConfirmLabel.setGraphicsEffect(self.opacity_effect)
         # set initial log table widths
-        self.logTable.setColumnWidth(0, 110)
-        self.logTable.setColumnWidth(1, 125)
-        self.logTable.setColumnWidth(2, 300)
+        self.activityLogTable.setColumnWidth(0, 110)
+        self.activityLogTable.setColumnWidth(1, 125)
+        self.activityLogTable.setColumnWidth(2, 300)

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -1455,31 +1455,76 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_37">
        <item>
-        <widget class="QScrollArea" name="scrollArea_6">
+        <widget class="QScrollArea" name="scrollAreaLog">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents_6">
+         <widget class="QWidget" name="scrollAreaWidgetContentsLog">
           <property name="geometry">
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>516</width>
-            <height>383</height>
+            <width>518</width>
+            <height>385</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_35">
            <item>
-            <widget class="QGroupBox" name="groupBox_6">
-             <property name="title">
-              <string>Log</string>
+            <widget class="QFrame" name="logFrame">
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_36">
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_50">
               <item>
-               <widget class="QTextEdit" name="logTextEdit">
-                <property name="readOnly">
-                 <bool>true</bool>
+               <widget class="QFrame" name="logTitleFrame">
+                <property name="frameShape">
+                 <enum>QFrame::NoFrame</enum>
                 </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Raised</enum>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_36">
+                 <item>
+                  <widget class="QLabel" name="logTitleLabel">
+                   <property name="font">
+                    <font>
+                     <pointsize>13</pointsize>
+                     <bold>false</bold>
+                    </font>
+                   </property>
+                   <property name="frameShadow">
+                    <enum>QFrame::Plain</enum>
+                   </property>
+                   <property name="text">
+                    <string>Log</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="logTableFrame">
+                <property name="frameShape">
+                 <enum>QFrame::NoFrame</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Raised</enum>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_38">
+                 <item>
+                  <widget class="QTableWidget" name="logTable"/>
+                 </item>
+                </layout>
                </widget>
               </item>
              </layout>

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -161,7 +161,7 @@
       </font>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>5</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -1430,20 +1430,20 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="log">
+     <widget class="QWidget" name="activityLog">
       <attribute name="title">
-       <string>Log</string>
+       <string>Activity Log</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_37">
        <item>
-        <widget class="QScrollArea" name="scrollAreaLog">
+        <widget class="QScrollArea" name="scrollAreaActivityLog">
          <property name="frameShape">
           <enum>QFrame::NoFrame</enum>
          </property>
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
-         <widget class="QWidget" name="scrollAreaWidgetContentsLog">
+         <widget class="QWidget" name="scrollAreaWidgetContentsActivityLog">
           <property name="geometry">
            <rect>
             <x>0</x>
@@ -1454,7 +1454,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_35">
            <item>
-            <widget class="QFrame" name="logFrame">
+            <widget class="QFrame" name="activityLogFrame">
              <property name="frameShape">
               <enum>QFrame::StyledPanel</enum>
              </property>
@@ -1463,7 +1463,7 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_50">
               <item>
-               <widget class="QFrame" name="logTitleFrame">
+               <widget class="QFrame" name="activityLogTitleFrame">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
                 </property>
@@ -1472,7 +1472,7 @@
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_36">
                  <item>
-                  <widget class="QLabel" name="logTitleLabel">
+                  <widget class="QLabel" name="activityLogTitleLabel">
                    <property name="font">
                     <font>
                      <pointsize>13</pointsize>
@@ -1483,7 +1483,7 @@
                     <enum>QFrame::Plain</enum>
                    </property>
                    <property name="text">
-                    <string>Log</string>
+                    <string>Activity Log</string>
                    </property>
                    <property name="alignment">
                     <set>Qt::AlignCenter</set>
@@ -1494,7 +1494,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QFrame" name="logTableFrame">
+               <widget class="QFrame" name="activityLogTableFrame">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
                 </property>
@@ -1503,7 +1503,7 @@
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_38">
                  <item>
-                  <widget class="QTableWidget" name="logTable">
+                  <widget class="QTableWidget" name="activityLogTable">
                    <property name="columnCount">
                     <number>3</number>
                    </property>

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -161,7 +161,7 @@
       </font>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>5</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -195,8 +195,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>495</width>
-            <height>534</height>
+            <width>501</width>
+            <height>428</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -479,8 +479,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>512</width>
-            <height>460</height>
+            <width>518</width>
+            <height>385</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -774,9 +774,9 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-82</y>
-            <width>495</width>
-            <height>554</height>
+            <y>0</y>
+            <width>501</width>
+            <height>448</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1034,9 +1034,9 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-220</y>
-            <width>495</width>
-            <height>680</height>
+            <y>0</y>
+            <width>501</width>
+            <height>587</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1291,8 +1291,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>512</width>
-            <height>460</height>
+            <width>518</width>
+            <height>385</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_34">
@@ -1464,8 +1464,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>510</width>
-            <height>458</height>
+            <width>516</width>
+            <height>383</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_35">
@@ -1476,7 +1476,7 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_36">
               <item>
-               <widget class="QTextEdit" name="textEdit">
+               <widget class="QTextEdit" name="logTextEdit">
                 <property name="readOnly">
                  <bool>true</bool>
                 </property>

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -1494,6 +1494,28 @@
                </widget>
               </item>
               <item>
+               <widget class="QFrame" name="activityLogDescriptionFrame">
+                <property name="frameShape">
+                 <enum>QFrame::NoFrame</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Raised</enum>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_49">
+                 <item>
+                  <widget class="QLabel" name="activityLogDescriptionLabel">
+                   <property name="text">
+                    <string>Keeps a history of all operations in the current QGIS session.</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
                <widget class="QFrame" name="activityLogTableFrame">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -161,7 +161,7 @@
       </font>
      </property>
      <property name="currentIndex">
-      <number>5</number>
+      <number>3</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -195,8 +195,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>501</width>
-            <height>428</height>
+            <width>530</width>
+            <height>385</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -479,7 +479,7 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>518</width>
+            <width>530</width>
             <height>385</height>
            </rect>
           </property>
@@ -775,8 +775,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>501</width>
-            <height>448</height>
+            <width>513</width>
+            <height>391</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -1035,8 +1035,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>501</width>
-            <height>587</height>
+            <width>513</width>
+            <height>535</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1291,7 +1291,7 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>518</width>
+            <width>530</width>
             <height>385</height>
            </rect>
           </property>
@@ -1347,11 +1347,20 @@
                 <layout class="QVBoxLayout" name="verticalLayout_49">
                  <item>
                   <widget class="QLabel" name="activityLogDescriptionLabel">
+                   <property name="minimumSize">
+                    <size>
+                     <width>250</width>
+                     <height>0</height>
+                    </size>
+                   </property>
                    <property name="text">
                     <string>A history of all operations in the current QGIS session.</string>
                    </property>
                    <property name="alignment">
                     <set>Qt::AlignCenter</set>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>
@@ -1419,7 +1428,7 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>518</width>
+            <width>530</width>
             <height>385</height>
            </rect>
           </property>

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -161,7 +161,7 @@
       </font>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>4</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -1345,6 +1345,9 @@
                  <enum>QFrame::Raised</enum>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_49">
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
                  <item>
                   <widget class="QLabel" name="activityLogDescriptionLabel">
                    <property name="minimumSize">

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -1348,7 +1348,7 @@
                  <item>
                   <widget class="QLabel" name="activityLogDescriptionLabel">
                    <property name="text">
-                    <string>Keeps a history of all operations in the current QGIS session.</string>
+                    <string>A history of all operations in the current QGIS session.</string>
                    </property>
                    <property name="alignment">
                     <set>Qt::AlignCenter</set>

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -1522,7 +1522,26 @@
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_38">
                  <item>
-                  <widget class="QTableWidget" name="logTable"/>
+                  <widget class="QTableWidget" name="logTable">
+                   <property name="columnCount">
+                    <number>3</number>
+                   </property>
+                   <column>
+                    <property name="text">
+                     <string>Activity</string>
+                    </property>
+                   </column>
+                   <column>
+                    <property name="text">
+                     <string>Timestamp</string>
+                    </property>
+                   </column>
+                   <column>
+                    <property name="text">
+                     <string>Link to Arches resource</string>
+                    </property>
+                   </column>
+                  </widget>
                  </item>
                 </layout>
                </widget>

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -161,7 +161,7 @@
       </font>
      </property>
      <property name="currentIndex">
-      <number>5</number>
+      <number>4</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -1402,25 +1402,6 @@
                   <widget class="QCheckBox" name="hidePostgresLayers">
                    <property name="text">
                     <string>Hide PostgreSQL layers</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QFrame" name="enableLoggingFrame">
-                <property name="frameShape">
-                 <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="frameShadow">
-                 <enum>QFrame::Plain</enum>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout_49">
-                 <item>
-                  <widget class="QCheckBox" name="enableLoggingCheckbox">
-                   <property name="text">
-                    <string>Enable logging</string>
                    </property>
                   </widget>
                  </item>

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -1273,6 +1273,134 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="activityLog">
+      <attribute name="title">
+       <string>Activity Log</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_37">
+       <item>
+        <widget class="QScrollArea" name="scrollAreaActivityLog">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContentsActivityLog">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>518</width>
+            <height>385</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_35">
+           <item>
+            <widget class="QFrame" name="activityLogFrame">
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_50">
+              <item>
+               <widget class="QFrame" name="activityLogTitleFrame">
+                <property name="frameShape">
+                 <enum>QFrame::NoFrame</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Raised</enum>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_36">
+                 <item>
+                  <widget class="QLabel" name="activityLogTitleLabel">
+                   <property name="font">
+                    <font>
+                     <pointsize>13</pointsize>
+                     <bold>false</bold>
+                    </font>
+                   </property>
+                   <property name="frameShadow">
+                    <enum>QFrame::Plain</enum>
+                   </property>
+                   <property name="text">
+                    <string>Activity Log</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="activityLogDescriptionFrame">
+                <property name="frameShape">
+                 <enum>QFrame::NoFrame</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Raised</enum>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_49">
+                 <item>
+                  <widget class="QLabel" name="activityLogDescriptionLabel">
+                   <property name="text">
+                    <string>Keeps a history of all operations in the current QGIS session.</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QFrame" name="activityLogTableFrame">
+                <property name="frameShape">
+                 <enum>QFrame::NoFrame</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Raised</enum>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_38">
+                 <item>
+                  <widget class="QTableWidget" name="activityLogTable">
+                   <property name="columnCount">
+                    <number>3</number>
+                   </property>
+                   <column>
+                    <property name="text">
+                     <string>Activity</string>
+                    </property>
+                   </column>
+                   <column>
+                    <property name="text">
+                     <string>Timestamp</string>
+                    </property>
+                   </column>
+                   <column>
+                    <property name="text">
+                     <string>Arches resource</string>
+                    </property>
+                   </column>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="settings">
       <attribute name="title">
        <string>Settings</string>
@@ -1423,134 +1551,6 @@
               </size>
              </property>
             </spacer>
-           </item>
-          </layout>
-         </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="activityLog">
-      <attribute name="title">
-       <string>Activity Log</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_37">
-       <item>
-        <widget class="QScrollArea" name="scrollAreaActivityLog">
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
-         </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="scrollAreaWidgetContentsActivityLog">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>518</width>
-            <height>385</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_35">
-           <item>
-            <widget class="QFrame" name="activityLogFrame">
-             <property name="frameShape">
-              <enum>QFrame::StyledPanel</enum>
-             </property>
-             <property name="frameShadow">
-              <enum>QFrame::Raised</enum>
-             </property>
-             <layout class="QVBoxLayout" name="verticalLayout_50">
-              <item>
-               <widget class="QFrame" name="activityLogTitleFrame">
-                <property name="frameShape">
-                 <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="frameShadow">
-                 <enum>QFrame::Raised</enum>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout_36">
-                 <item>
-                  <widget class="QLabel" name="activityLogTitleLabel">
-                   <property name="font">
-                    <font>
-                     <pointsize>13</pointsize>
-                     <bold>false</bold>
-                    </font>
-                   </property>
-                   <property name="frameShadow">
-                    <enum>QFrame::Plain</enum>
-                   </property>
-                   <property name="text">
-                    <string>Activity Log</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QFrame" name="activityLogDescriptionFrame">
-                <property name="frameShape">
-                 <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="frameShadow">
-                 <enum>QFrame::Raised</enum>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout_49">
-                 <item>
-                  <widget class="QLabel" name="activityLogDescriptionLabel">
-                   <property name="text">
-                    <string>Keeps a history of all operations in the current QGIS session.</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QFrame" name="activityLogTableFrame">
-                <property name="frameShape">
-                 <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="frameShadow">
-                 <enum>QFrame::Raised</enum>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout_38">
-                 <item>
-                  <widget class="QTableWidget" name="activityLogTable">
-                   <property name="columnCount">
-                    <number>3</number>
-                   </property>
-                   <column>
-                    <property name="text">
-                     <string>Activity</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>Timestamp</string>
-                    </property>
-                   </column>
-                   <column>
-                    <property name="text">
-                     <string>Arches resource</string>
-                    </property>
-                   </column>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </widget>
            </item>
           </layout>
          </widget>

--- a/arches_project/ui/arches_project_dialog_base.ui
+++ b/arches_project/ui/arches_project_dialog_base.ui
@@ -1541,7 +1541,7 @@
                    </column>
                    <column>
                     <property name="text">
-                     <string>Link to Arches resource</string>
+                     <string>Arches resource</string>
                     </property>
                    </column>
                   </widget>


### PR DESCRIPTION
This PR adds an activity log in a pre-existing, but unused, log tab. Currently there are three columns:

- Activity
- Timestamp
- Link to Arches Resource

New entries are added to the top of the table, so that the most recent actions show first. Allowing the user to sort the table is not currently enabled, but it could be implemented. 

The links column uses QLabels in the cells rather than QTableWidgetItem, as this allows html links. It's possible to have links by double clicking on the full QTableWidgetItem cell, but I thought the normal html links would be nicer. The downside is that if we did allow sorting, then it wouldn't work on that column, but it's unlikely anyone would want to sort by Arches ID anyway.

The more major issue currently is that the table won't persist between sessions. Given that the number of log entries could get quite large for some users / organisations, I think we'd have to write to a db, or at least a file, at the same time as updating the on-screen table. 

Another possible expansion in the future would be to allow filtering / searching. 

The currently functionality is shown below. Note that due to https://github.com/archesproject/arches-qgis/issues/105 the Create Resource duplicates the previous geometry replacement. 

https://github.com/user-attachments/assets/d5210f18-bb24-4689-9849-bad372ba6c60

Closes https://github.com/archesproject/arches-qgis/issues/97


