### PR TITLE
Clear login fields only if logging out

### DIFF
--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -21,7 +21,7 @@ def connection_reset(hard_reset, dlg, iface, manual_logout=False):
         dlg.tabWidget.setTabVisible(1, False)
         dlg.tabWidget.setCurrentIndex(0)
         # Reset connection inputs
-        if manual_logout:
+        if manual_logout == True:
             dlg.archesServerInput.setText("")
             dlg.usernameInput.setText("")
             dlg.passwordInput.setText("")
@@ -53,7 +53,7 @@ def connection_reset(hard_reset, dlg, iface, manual_logout=False):
     # Reload saved credentials for the autocompletes
     load_saved_credentials(dlg)
 
-    if manual_logout:
+    if manual_logout == True:
         show_message(
             iface,
             "information",

--- a/arches_project/core/views/components/dialog_updates.py
+++ b/arches_project/core/views/components/dialog_updates.py
@@ -12,10 +12,6 @@ def connection_reset(hard_reset, dlg, iface, manual_logout=False):
     Reset Arches connection
     """
     if hard_reset == True:
-        # Reset connection inputs
-        dlg.archesServerInput.setText("")
-        dlg.usernameInput.setText("")
-        dlg.passwordInput.setText("")
         # Reset logged in values
         dlg.displayFullNameLabel.setText("")
         dlg.displayConnectionInfoLabel.setText("")
@@ -24,6 +20,11 @@ def connection_reset(hard_reset, dlg, iface, manual_logout=False):
         dlg.tabWidget.setTabVisible(0, True)
         dlg.tabWidget.setTabVisible(1, False)
         dlg.tabWidget.setCurrentIndex(0)
+        # Reset connection inputs
+        if manual_logout:
+            dlg.archesServerInput.setText("")
+            dlg.usernameInput.setText("")
+            dlg.passwordInput.setText("")
 
     # Reset stored data
     arches_api.arches_user_info = {}


### PR DESCRIPTION
This PR makes resetting the login fields conditional on manual_logout being set to True, which means that a failed log-in attempt won't clear the fields, but logging out will. 

Closes https://github.com/archesproject/arches-qgis/issues/104