### PR TITLE
Disconnect the 'create resource' confirmation btn, before reconnecting

### DIFF
--- a/arches_project/core/arches/resources.py
+++ b/arches_project/core/arches/resources.py
@@ -161,9 +161,11 @@ class ArchesResources:
         dlg_resource_confirmation.show()
 
         # Push button responses
+        dlg_resource_confirmation.confirmDialogConfirm.disconnect()
         dlg_resource_confirmation.confirmDialogConfirm.clicked.connect(
             send_new_resource_to_arches
         )
+        dlg_resource_confirmation.confirmDialogCancel.disconnect()
         dlg_resource_confirmation.confirmDialogCancel.clicked.connect(close_dialog)
 
     def edit_resource(


### PR DESCRIPTION
This fix disconnects the signal to `send_new_resource_to_arches` before it gets reapplied, as part of the `create_resource` method. This process already happens within `edit_resource`.

As a follow up, it may be worth moving this code into `resource_confirmation_dialog.py` and importing the functions from `resources.py`. This would mean it only gets run once, and disconnecting each time wouldn't be necessary. 

Closes https://github.com/archesproject/arches-qgis/issues/105