### PR TITLE
Fix first load auto-correct error

### DIFF
--- a/arches_project/ui/widgets/auto_complete_line_edit.py
+++ b/arches_project/ui/widgets/auto_complete_line_edit.py
@@ -9,4 +9,5 @@ class AutoCompleteLineEdit(QLineEdit):
     def focusInEvent(self, event):
         super().focusInEvent(event)
         completer = self.completer()
-        completer.complete()
+        if completer:
+            completer.complete()


### PR DESCRIPTION
Adds an if statement so that the completer only gets called if it's truthy (i.e. not None). 

Closes https://github.com/archesproject/arches-qgis/issues/146